### PR TITLE
Added initial ADRs, README section on ADRs and ADR template

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,27 @@
+= Stackable Documentation
+== Introduction
+
+tbd
+
+== Architectural Design Decisions
+All relevant decisions concerning the architecture are documented as Architectural Design Records in the subfolder _adr_.
+
+Unfinished or not yet approved decisions are stored in the _adr/drafts_ subfolder.
+This folder also contains a template that can be used for creating new decision records.
+
+*Naming Convention* +
+When creating a new record, please use the following guidelines for file naming:
+
+ ADR[number]-[name].adoc
+
+During the draft stage please substitute x for the number.
+For the name, please use only lower case letters, number and the underscore.
+Ideally start the name with the imperative form of a verb and avoid fillers like _of/the/for/..._
+
+Some examples:
+
+* choose_project_language
+* choose_repository_structure
+* choose_review_mechanism
+
+When choosing the next free number after an ADR has been approved, make sure to left pad the number with 0 to reach a length of three digits.

--- a/adr/ADR001-choose_project_language.adoc
+++ b/adr/ADR001-choose_project_language.adoc
@@ -1,0 +1,54 @@
+= Use English as Documentation Language
+Sönke Liebau <soenke.liebau@stackable.de>
+v1.0, 19.08.2020
+:status: accepted
+
+* Status: {status}
+* Deciders:
+** Florian Waibel
+** Lars Francke
+** Lukas Menzel
+** Oliver Hessel
+** Sönke Liebau
+* Date: 19.08.2020
+
+== Context and Problem Statement
+
+For all documentation, presentations, inline comments etc. we need to agree on which language to use.
+As currently all participants are German, the first choice would be German, however as this is intended to grow an active, international community the choice of German would exclude many people or lead to fragmentation of the community.
+
+== Decision Drivers
+
+* Familiarity of existing team members
+* Potential to grow an open community
+
+== Considered Options
+
+* German
+* English
+
+== Decision Outcome
+
+Chosen option: "English", because the desire to create an active community with participants from all over the world is much more important than the minor barrier that this decision might create initally.
+
+=== Positive Consequences
+
+* The barrier for particiption for international members is much lower in later community work
+* The risk of the community fragmenting into a german community and an international community is much lower
+* Higher pool of candidates to help out during the initial project phase
+
+=== Negative Consequences
+
+* Initially the team would need to document in a language that is not a first language for anybody
+
+== Pros and Cons of the Options
+
+=== German
+
+* Good, because first language for most current team members
+* Bad, because excludes a lot of people from the later community or would create a split in the community
+
+=== English
+
+* Good, because it allows growing an international community
+* Bad, would initially add a small language barrier that is not strictly speaking necessary

--- a/adr/ADR002-choose_repository_structure.adoc
+++ b/adr/ADR002-choose_repository_structure.adoc
@@ -1,0 +1,80 @@
+= Use Multiple Repositories instead of one Large Repository
+Sönke Liebau <soenke.liebau@stackable.de>
+v1.0, 19.08.2020
+:status: accepted
+
+* Status: {status}
+* Deciders:
+** Florian Waibel
+** Lars Francke
+** Lukas Menzel
+** Oliver Hessel
+** Sönke Liebau
+* Date: 19.08.2020
+
+== Context and Problem Statement
+
+Should we use one large repository for all components of the project or structure this into multiple smaller repositories?
+
+== Decision Drivers
+
+* Useability of repository structure
+* Impact on related infrastructure like CI / Testing / ...
+* Impact on release strategy
+
+== Considered Options
+
+* Single Repository
+* Multiple Repositories
+
+== Decision Outcome
+
+Chosen option: "Multiple Repositories", because it comes out best (see below)].
+
+How to split the components into repositories will be decided throughout the runtime of the project.
+
+Initially the following repositories were identified:
+
+* Orchestrator
+* Agent
+* ADR / Documentation
+* Operators (most probably one repository per operator)
+* Stackbit Sources (most probably one repository per product)
+
+=== Positive Consequences
+
+* The ability to separate changes to different modules
+* Better organization of individual modules
+* Better separation of releases between modules
+
+=== Negative Consequences
+
+* No single place to search for things, a little familiarity with the repository structure might be needed
+* Potentially more effort when setting up CI and testing infrastructure
+
+== Pros and Cons of the Options
+
+=== Single Repository
+
+* Good, because it makes implementing dependencies between modules easier
+* Good, because it provides a single place to search for _things_
+* Bad, because it can become large and difficult to manage
+* Bad, because it keeps things that should be loosely coupled in the same place which might promote tighter coupling
+* Bad, because tagging a release of a component will unnecessarily include the rest of the repository
+* Bad, because changes to a component may accidentally impact other components
+* Bad, because the commit history is mixed for all components
+* Bad, because a single commit may change multiple components making tracking these changes harder
+* Bad, because the CI pipeline would need to identify the changed components to avoid triggering tests for all other components
+* Bad, because clone times might be much higher
+
+=== Multiple Repositories
+
+* Good, because it keeps the individual repositories simpler
+* Good, because it allows proper separation of modules
+* Good, because it allows proper tagging of releases
+* Bad, because implementing dependent changes in separate components becomes harder
+* Bad, because it makes finding individual pieces of code potentially harder if the repository is unknown
+
+== Links
+
+* https://medium.com/@johnclarke_82232/mono-or-multi-repo-6c3674142dfc[Mono- or Multi-repo?]

--- a/adr/ADR003-choose_review_mechanism.adoc
+++ b/adr/ADR003-choose_review_mechanism.adoc
@@ -1,0 +1,70 @@
+= Use RTC as Review Mechanism for Changes
+Sönke Liebau <soenke.liebau@stackable.de>
+v1.0, 19.08.2020
+:status: accepted
+
+* Status: {status}
+* Deciders:
+** Florian Waibel
+** Lars Francke
+** Lukas Menzel
+** Oliver Hessel
+** Sönke Liebau
+* Date: 19.08.2020
+
+== Context and Problem Statement
+
+We need a review process in place to ensure that any change that is committed into any of this projects repositories is properly reviewed.
+In order to do this there are two main principles that have been coined by the Apache Software Foundation:
+
+* Commit the change and then ensure that someone reviews it and commits necessary changes
+* Create a pull request that is reviewed and changed before it gets merged into the main branch
+
+== Decision Drivers
+
+* Keep the commit history clean
+* Ensure only reviewed code ever gets released
+
+== Considered Options
+
+* Review then commit
+* Commit then review
+
+
+== Decision Outcome
+
+Chosen option: "Review then commit", because it meets both decision drivers.
+
+=== Positive Consequences
+
+* It is easy to ensure that no unreviewed code gets into a release
+* No need to track which code still needs to be reviewed
+* The commit history can be kept much cleaner as all commits can be squashed when merging a pull request
+
+=== Negative Consequences
+
+* Quick fixes may become harder, as reviewers need to be found before a fix can be merged
+* Pull requests may go stale and cause a little effort to rebase before they can be merged
+
+== Pros and Cons of the Options
+
+=== Review then commit
+
+This option requires a full review and approval of all changes before they are commited to the development branch.
+Who and how many people need to approve a change will need to be defined in the contribution guidelines at a later time.
+
+* Good, because there is no need to keep track of unreviewed commits
+* Good, because it is much easier to keep the commit history clean
+* Good, because discussions during review are kept in the PR which keeps the repository clean
+* Bad, because _quick fixes_ can become harder
+* Bad, because pull requests may go stale
+* Bad, because a large number of old and inactive pull requests may accumulate
+
+=== Commit then Review
+
+With this process any committer is allowed to commit changes straight to the
+
+* Good, because committing a change quickly is much easier
+* Bad, because unreviewed commits could make it into a release or would need to be excluded
+* Bad, because we need to keep track of whether or not a commit has been reviewed yet
+* Bad, because changes during review would create additional commits that clutter up the commit history

--- a/adr/drafts/_template.adoc
+++ b/adr/drafts/_template.adoc
@@ -1,0 +1,75 @@
+= [short title of solved problem and solution]
+Doc Writer <doc.writer@asciidoctor.org>
+v0.1, dd.mm.yyyy
+:status: [draft | rejected | accepted | deprecated | … | superseded by link:0005-example.md[ADR-0005]]
+
+* Status: {status}
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+== Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+== Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+== Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* … <!-- numbers of options can vary -->
+
+== Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+=== Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+=== Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+== Pros and Cons of the Options <!-- optional -->
+
+=== [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+=== [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+=== [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+== Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->


### PR DESCRIPTION
Added initial ADRs that were agreed during the design call on 19th of August 2020:

- choose project language
- choose repo structure
- choose review mechanism

Added an ADR template.

Added a very brief documentation of how to create new ADRs to README.adoc