### PR TITLE
Add monitoring-operator to docs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -6,15 +6,15 @@ site:
 
 content:
   sources: 
-  - url: https://github.com/stackabletech/documentation.git
-    branches: main
   - url: https://github.com/stackabletech/agent.git
     branches: main
     start_path: docs
-  - url: https://github.com/stackabletech/hdfs-operator.git
+  - url: https://github.com/stackabletech/documentation.git
+    branches: main
+  - url: https://github.com/stackabletech/kafka-operator.git
     branches: main
     start_path: docs
-  - url: https://github.com/stackabletech/kafka-operator.git
+  - url: https://github.com/stackabletech/monitoring-operator.git
     branches: main
     start_path: docs
   - url: https://github.com/stackabletech/nifi-operator.git


### PR DESCRIPTION
(The funny branch name was created by VSCode)

Also removed hdfs-operator and sorted content sources alphabetically.

Fixes #79