### PR TITLE
ADR for authn token management

### DIFF
--- a/modules/adr/nav.adoc
+++ b/modules/adr/nav.adoc
@@ -10,6 +10,7 @@
 *** xref:ADR009-selector_support.adoc[]
 *** xref:ADR010-command_pattern.adoc[]
 *** xref:ADR011-directory_structure.adoc[]
+*** xref:ADR012-authn_token_management.adoc[]
 
 ** Deprecated
 *** xref:deprecated/ADR006-choose_orchestrator_storage_backend.adoc[]

--- a/modules/adr/pages/ADR012-authn_token_management.adoc
+++ b/modules/adr/pages/ADR012-authn_token_management.adoc
@@ -1,17 +1,18 @@
-= Authentication token management
+= ADR012: Authentication token management
 Teo Klestrup Röijezon <teo.roijezon@stackable.de>
-v0.1, dd.mm.yyyy
-:status: draft
+v0.1, 2021-11-23
+:status: accepted
 
 * Status: {status}
-* Deciders: [list everyone involved in the decision] <!-- optional -->
-* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+* Deciders:
+** Teo Klestrup Röijezon
+** Lars Francke
+** Sönke Liebau
+* Date: 2021-11-23
 
-Technical Story: [description | ticket/issue URL] <!-- optional -->
+Technical Story: https://github.com/stackabletech/issues/issues/4
 
 == Context and Problem Statement
-
-[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
 
 Services need a way to authenticate each other when communicating. This is typically done by issuing each service some form of secret token that the counterparty can validate. Depending on the service in question, this may be a token unique to the counterparty (such as a password or API key) or a token accepted by a whole trust domain (such as a Kerberos keytab or a TLS certificate). This ADR primarily concerns itself with the latter case.
 

--- a/modules/adr/pages/drafts/ADRx-authn_token_management.adoc
+++ b/modules/adr/pages/drafts/ADRx-authn_token_management.adoc
@@ -1,0 +1,89 @@
+= Authentication token management
+Teo Klestrup Röijezon <teo.roijezon@stackable.de>
+v0.1, dd.mm.yyyy
+:status: draft
+
+* Status: {status}
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+== Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+Services need a way to authenticate each other when communicating. This is typically done by issuing each service some form of secret token that the counterparty can validate. Depending on the service in question, this may be a token unique to the counterparty (such as a password or API key) or a token accepted by a whole trust domain (such as a Kerberos keytab or a TLS certificate). This ADR primarily concerns itself with the latter case.
+
+Depending on the specifics of the service being communicated with, this token may need to identify the replica (Pod in Kubernetes terms), the set of replicas (RoleGroup, StatefulSet, or Pod), or the server that the replica is running on (Node).
+
+== Decision Drivers
+
+* Depending on the specific service being communicated with, the token may need to identify the the replica (Pod in Kubernetes terms), the set of replicas (RoleGroup, StatefulSet, or Pod), or the server that the replica is running on (Node)
+* Some customers have an existing trust domain where they provision us static tokens that we must use
+* Many customers do not have an existing trust domain, nor do they want to take on the operational burden of managing it manually
+* Ideally, automatically provisioned tokens should be as short-lived as is practical
+
+== Considered Options
+
+1. Kubernetes secrets (+ Cert Manager etc)
+2. Hashicorp Vault
+3. Custom secret service
+
+== Decision Outcome
+
+**TBD**
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+=== Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+=== Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+== Pros and Cons of the Options
+
+=== Kubernetes secrets
+
+Secrets are managed in Kubernetes Secret objects, which are mounted into the Pods.
+
+Depending on the customer's configuration, these secrets may be provisioned by operators such as Cert-Manager, or managed manually by an administrator.
+
+* Good, because it exists already
+* Good, because people are already used to them
+* Bad, because secret mounting is static for the whole StatefulSet or Deployment (and so cannot depend on the replica or node identity)
+* Bad, because secrets must be provisioned in advance and stored in K8s
+* Bad, because Kubernetes Secrets are typically not encrypted at rest
+* Bad, because cluster and app administrators often have overly broad access to Secrets
+* Bad, because Cert-Manager does not perform any policy check on certificates being issued
+* Bad, because there is no Krb-Keytab-Manager (yet)
+
+=== Hashicorp Vault
+
+Secrets are stored or provisioned on demand by Hashicorp Vault, and injected into the pods using Vault-CSI.
+
+* Good, because it exists already
+* Good, because it can issue TLS certificates on demand
+* Good, because secrets are encrypted at rest
+* Bad, because it cannot issue Kerberos keytabs
+* Bad, because the APIs for issuing dynamic secrets and retrieving existing secrets are incompatible
+* Bad, because policy controls are limited enough to be nearly useless for managing identities
+* Bad, because it is a heavy operational burden for customers that do not already use it
+* Bad, because Vault Enterprise pricing is unclear (but has a reputation for being very expensive)
+
+=== Custom secret service
+
+Secrets are stored or provisioned by a custom service (which may delegate to Vault, Kubernetes, etc as needed). Secrets
+are injected into pods using a custom CSI provider or init container.
+
+* Good, because it can enforce policy for generated identities (for example: tying TLS certificate to Pod or Node identity)
+* Good, because it can pick pregenerated tokens based on Pod/Node identity
+* Good, because it can have a cluster-global policy for picking between backends
+* Good, because it can accomodate to whatever authn methods we end up supporting
+* Bad, because it's another bespoke thing to maintain and develop
+* Bad, because none of us are experienced with writing CSI providers

--- a/modules/adr/pages/drafts/ADRx-authn_token_management.adoc
+++ b/modules/adr/pages/drafts/ADRx-authn_token_management.adoc
@@ -32,19 +32,7 @@ Depending on the specifics of the service being communicated with, this token ma
 
 == Decision Outcome
 
-**TBD**
-
-Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
-
-=== Positive Consequences <!-- optional -->
-
-* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
-* …
-
-=== Negative Consequences <!-- optional -->
-
-* [e.g., compromising quality attribute, follow-up decisions required, …]
-* …
+**Option 3: Custom Secret Service**
 
 == Pros and Cons of the Options
 


### PR DESCRIPTION
Rendered: https://github.com/stackabletech/documentation/blob/adr/authn-tokens/modules/adr/pages/drafts/ADRx-authn_token_management.adoc

This is a generalization of https://github.com/stackabletech/issues/issues/4, taking into account other secret types, as well as organizationally managed secrets.

Personally I'm leaning towards doing a MVP of the custom secret service. IMO, using Secrets directly won't work well for services that care about node identities (anything that's exposed outside of the cluster), and my feeling is that relying on separate operators for each kind of secret will end up with a very disjointed experience. Vault is way too ops-heavy to have a hard dependency on, and as far as I can tell their policy framework isn't powerful enough to express our needs either.