### PR TITLE
Basic documentation on how to set up Prometheus monitoring

### DIFF
--- a/modules/ROOT/examples/monitoring-servicemonitor.yaml
+++ b/modules/ROOT/examples/monitoring-servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   endpoints:
   - port: metrics
-  jobLabel: app.kubernetes.io/name
+  jobLabel: app.kubernetes.io/instance
   selector:
     matchLabels:
       prometheus.io/scrape: "true"

--- a/modules/ROOT/examples/monitoring-servicemonitor.yaml
+++ b/modules/ROOT/examples/monitoring-servicemonitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: scrape-label
+  labels:
+    release: prometheus
+spec:
+  endpoints:
+  - port: metrics
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      prometheus.io/scrape: "true"

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,1 +1,2 @@
 * xref:getting_started.adoc[]
+* xref:monitoring.adoc[]

--- a/modules/ROOT/pages/monitoring.adoc
+++ b/modules/ROOT/pages/monitoring.adoc
@@ -1,0 +1,42 @@
+= Monitoring
+
+Services managed by Stackable support monitoring via https://prometheus.io/[Prometheus].
+
+== Prometheus Operator
+
+Stackable does not currently provide Prometheus, instead we suggest using
+https://prometheus-operator.dev/[Prometheus Operator].
+
+=== Installing Prometheus
+
+Prometheus Operator can be installed via the Helm chart `kube-prometheus-stack`, which includes
+both the Operator, and a basic Prometheus configuration that should be sufficient for basic use.
+
+[source,bash]
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm upgrade prometheus prometheus-community/kube-prometheus-stack --install --version 31.0.0
+
+When using the `kube-prometheus-stack` Helm chart (as above), an additional `ServiceMonitor` must be applied to
+the Kubernetes cluster, which discovers services registered to the Kubernetes cluster:
+
+[source,yaml]
+----
+include::example$monitoring-servicemonitor.yaml[]
+----
+
+=== Querying Prometheus
+
+Prometheus should now be accessible inside of the Kubernetes cluster, and can be access can be forwarded using `kubectl`:
+
+[source,bash]
+kubectl port-forward svc/prometheus-kube-prometheus-prometheus 9090
+
+Afterwards, we can go to http://localhost:9090/ to access the query UI.
+
+== Existing Prometheus
+
+An existing Prometheus installation can also be used to monitor Stackable services.
+
+In this case, it should be configured to scrape Kubernetes `Service` objects with the label `prometheus.io/scrape: "true"`.
+For more details, see their official documentation for
+https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config[`<kubernetes_sd_config>`].


### PR DESCRIPTION
Fixes #131.

This is just intended as a basic getting-started guide for now. This does NOT cover:

- HA
- Prom-per-node (see https://github.com/stackabletech/issues/issues/165)
- Thanos archival
- Alerts
- Grafana