### PR TITLE
Document supported ZooKeeper/Kafka versions

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,1 +1,2 @@
 * xref:getting_started.adoc[]
+* xref:supported-versions.adoc[]

--- a/modules/ROOT/pages/supported-versions.adoc
+++ b/modules/ROOT/pages/supported-versions.adoc
@@ -1,0 +1,7 @@
+= Supported Product Versions
+
+The latest versions of each of the Stackable Operators support the following product versions:
+
+== Apache ZooKeeper
+
+include::zookeeper::partial$supported-versions.adoc[]

--- a/modules/ROOT/pages/supported-versions.adoc
+++ b/modules/ROOT/pages/supported-versions.adoc
@@ -5,3 +5,7 @@ The latest versions of each of the Stackable Operators support the following pro
 == Apache ZooKeeper
 
 include::zookeeper::partial$supported-versions.adoc[]
+
+== Apache Kafka
+
+include::kafka::partial$supported-versions.adoc[]


### PR DESCRIPTION
This provides a starting point for #121, pulling in the data from each supported product operator.

Depends on https://github.com/stackabletech/zookeeper-operator/pull/381.