### PR TITLE
Move navbar into documentation repo

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -54,7 +54,7 @@ content:
 ui:
   bundle:
     url: ./ui/build/ui-bundle.zip
-  supplemental_files: ./node_modules/@antora/lunr-extension/supplemental_ui
+  supplemental_files: ./supplemental-ui
 
 antora:
   extensions:

--- a/supplemental-ui/css/search.css
+++ b/supplemental-ui/css/search.css
@@ -1,0 +1,1 @@
+../../node_modules/@antora/lunr-extension/supplemental_ui/css/search.css

--- a/supplemental-ui/js/search-ui.js
+++ b/supplemental-ui/js/search-ui.js
@@ -1,0 +1,1 @@
+../../node_modules/@antora/lunr-extension/supplemental_ui/js/search-ui.js

--- a/supplemental-ui/partials/navbar.hbs
+++ b/supplemental-ui/partials/navbar.hbs
@@ -1,0 +1,21 @@
+<a class="navbar-sub-item" href="{{{ relativize "/home/index.html" }}}">Overview</a>
+<a class="navbar-sub-item" href="{{{ relativize "/home/index.html" }}}">Architecture</a>
+<a class="navbar-sub-item" href="{{{ relativize "/home/getting_started.html" }}}">Getting Started</a>
+<div class="navbar-sub-item drop-down">
+    Operators
+    <div class="drop-down-content">
+    <a class="drop-down-item" href="{{{ relativize "/airflow/index.html" }}}">Apache Airflow</a>
+    <a class="drop-down-item" href="{{{ relativize "/druid/index.html" }}}">Apache Druid</a>
+    <a class="drop-down-item" href="{{{ relativize "/hbase/index.html" }}}">Apache HBase</a>
+    <a class="drop-down-item" href="{{{ relativize "/hdfs/index.html" }}}">Apache Hadoop HDFS</a>
+    <a class="drop-down-item" href="{{{ relativize "/hive/index.html" }}}">Apache Hive</a>
+    <a class="drop-down-item" href="{{{ relativize "/kafka/index.html" }}}">Apache Kafka</a>
+    <a class="drop-down-item" href="{{{ relativize "/nifi/index.html" }}}">Apache NiFi</a>
+    <a class="drop-down-item" href="{{{ relativize "/spark/index.html" }}}">Apache Spark</a>
+    <a class="drop-down-item" href="{{{ relativize "/superset/index.html" }}}">Apache Superset</a>
+    <a class="drop-down-item" href="{{{ relativize "/trino/index.html" }}}">Trino</a>
+    <a class="drop-down-item" href="{{{ relativize "/zookeeper/index.html" }}}">Apache ZooKeeper</a>
+    <a class="drop-down-item" href="{{{ relativize "/opa/index.html" }}}">OpenPolicyAgent</a>
+    <a class="drop-down-item" href="{{{ relativize "/secret-operator/index.html" }}}">Secret</a>
+    </div>
+</div>


### PR DESCRIPTION
This depends on https://github.com/stackabletech/documentation-ui/pull/8 for it to actually be respected.