### PR TITLE
Fixed menu links now that versions are supported

### DIFF
--- a/supplemental-ui/partials/navbar.hbs
+++ b/supplemental-ui/partials/navbar.hbs
@@ -5,21 +5,21 @@
     Operators
     <div class="drop-down-content">
     <a class="drop-down-item" href="{{{ relativize "/home/operators/index.html" }}}">Overview</a>
-    <a class="drop-down-item" href="{{{ relativize "/airflow/index.html" }}}">Apache Airflow</a>
-    <a class="drop-down-item" href="{{{ relativize "/druid/index.html" }}}">Apache Druid</a>
-    <a class="drop-down-item" href="{{{ relativize "/hbase/index.html" }}}">Apache HBase</a>
-    <a class="drop-down-item" href="{{{ relativize "/hdfs/index.html" }}}">Apache Hadoop HDFS</a>
-    <a class="drop-down-item" href="{{{ relativize "/hive/index.html" }}}">Apache Hive</a>
-    <a class="drop-down-item" href="{{{ relativize "/kafka/index.html" }}}">Apache Kafka</a>
-    <a class="drop-down-item" href="{{{ relativize "/nifi/index.html" }}}">Apache NiFi</a>
-    <a class="drop-down-item" href="{{{ relativize "/spark/index.html" }}}">Apache Spark (standalone)</a>
-    <a class="drop-down-item" href="{{{ relativize "/spark-k8s/index.html" }}}">Apache Spark on K8S</a>
-    <a class="drop-down-item" href="{{{ relativize "/superset/index.html" }}}">Apache Superset</a>
-    <a class="drop-down-item" href="{{{ relativize "/trino/index.html" }}}">Trino</a>
-    <a class="drop-down-item" href="{{{ relativize "/zookeeper/index.html" }}}">Apache ZooKeeper</a>
-    <a class="drop-down-item" href="{{{ relativize "/opa/index.html" }}}">OpenPolicyAgent</a>
-    <a class="drop-down-item" href="{{{ relativize "/commons-operator/index.html" }}}">Commons</a>
-    <a class="drop-down-item" href="{{{ relativize "/secret-operator/index.html" }}}">Secret</a>
+    <a class="drop-down-item" href="{{{ relativize "/airflow/nightly/index.html" }}}">Apache Airflow</a>
+    <a class="drop-down-item" href="{{{ relativize "/druid/nightly/index.html" }}}">Apache Druid</a>
+    <a class="drop-down-item" href="{{{ relativize "/hbase/nightly/index.html" }}}">Apache HBase</a>
+    <a class="drop-down-item" href="{{{ relativize "/hdfs/nightly/index.html" }}}">Apache Hadoop HDFS</a>
+    <a class="drop-down-item" href="{{{ relativize "/hive/nightly/index.html" }}}">Apache Hive</a>
+    <a class="drop-down-item" href="{{{ relativize "/kafka/nightly/index.html" }}}">Apache Kafka</a>
+    <a class="drop-down-item" href="{{{ relativize "/nifi/nightly/index.html" }}}">Apache NiFi</a>
+    <a class="drop-down-item" href="{{{ relativize "/spark/nightly/index.html" }}}">Apache Spark (standalone)</a>
+    <a class="drop-down-item" href="{{{ relativize "/spark-k8s/nightly/index.html" }}}">Apache Spark on K8S</a>
+    <a class="drop-down-item" href="{{{ relativize "/superset/nightly/index.html" }}}">Apache Superset</a>
+    <a class="drop-down-item" href="{{{ relativize "/trino/nightly/index.html" }}}">Trino</a>
+    <a class="drop-down-item" href="{{{ relativize "/zookeeper/nightly/index.html" }}}">Apache ZooKeeper</a>
+    <a class="drop-down-item" href="{{{ relativize "/opa/nightly/index.html" }}}">OpenPolicyAgent</a>
+    <a class="drop-down-item" href="{{{ relativize "/commons-operator/nightly/index.html" }}}">Commons</a>
+    <a class="drop-down-item" href="{{{ relativize "/secret-operator/nightly/index.html" }}}">Secret</a>
     </div>
 </div>
 <a class="navbar-sub-item" href="{{{ relativize "/home/contributor/index.html" }}}">Contribute</a>


### PR DESCRIPTION
I added the `/nightly` to all the menu paths for now, because the links are currently broken.