### PR TITLE
Documentation style guide

### DIFF
--- a/modules/contributor/nav.adoc
+++ b/modules/contributor/nav.adoc
@@ -4,5 +4,6 @@
 ** xref:development_dashboard.adoc[]
 ** xref:service_discovery.adoc[]
 ** xref:opa_configuration.adoc[]
+** xref:style_guide.adoc[]
 
 include::partial$adr-nav.adoc[]

--- a/modules/contributor/pages/steps.adoc
+++ b/modules/contributor/pages/steps.adoc
@@ -56,7 +56,7 @@ helm install <operator> deploy/helm/<operator>/
 
 1. The Stackable Platform documentation can be found at https://docs.stackable.tech/. The documentation is built with Antora from the sources in the  https://github.com/stackabletech/documentation[documentation repository] and the `docs` directories in the operator repositories. Follow the steps in <<Preparation>> to be able to change the documentation.
 2. Make your changes.
-3. Create the documentation locally to ensure that the formatting is fine and all links are specified correctly. See the https://github.com/stackabletech/documentation/blob/main/README.adoc[`README.adoc`] file for further details.
+3. Create the documentation locally to ensure that the formatting is fine and all links are specified correctly. See the https://github.com/stackabletech/documentation/blob/main/README.adoc[`README.adoc`] file for further details and the xref:style_guide.adoc[] for style and formatting guidelines.
 
 == Changes in the operator-templating
 

--- a/modules/contributor/pages/style_guide.adoc
+++ b/modules/contributor/pages/style_guide.adoc
@@ -1,0 +1,14 @@
+# Documentation style guide
+
+// make this document a whole "How to contribute documentation" (?)
+// just a style guide?
+// should we document also stuff about the structure?
+// what about graphics?
+
+// graphics and a whole "How to contribute docs" is not in the scope
+// probably not to be done for now (even though it would be nice to have)
+// it sucks a bit to have the style guide a bit in a vacuum, but I think for now it would be fine. I could make a ticket for writing "How to contribute docs"
+
+For consistency and clarity, we provide some guidelines on how to write documentation.
+
+We follow the link:https://kubernetes.io/docs/contribute/style/style-guide/[Kubernetes documentation style guide] and the link:https://developers.google.com/style/[Google developer documentation style guide].

--- a/modules/contributor/pages/style_guide.adoc
+++ b/modules/contributor/pages/style_guide.adoc
@@ -9,11 +9,15 @@
 // probably not to be done for now (even though it would be nice to have)
 // it sucks a bit to have the style guide a bit in a vacuum, but I think for now it would be fine. I could make a ticket for writing "How to contribute docs"
 
-This page provides guidelines on how to write documentation for the Stackable platform. Style guidelines are provided specifying things such as capitalization rules, which format to use for emphasis or how API objects and other components should be styled in the documentation - formatting and "superficial" aspects of text. There are also guidelines on grammar, tone and voice, making the texts across the documentation consistent and as clear as possible; for example using a conversational tone, using second person and using active voice.
+This page provides guidelines on how to write documentation for the Stackable platform. Style guidelines specify things such as capitalization rules, which format to use for emphasis or how API objects and other components should be styled in the documentation - formatting and "superficial" aspects of text. Grammar, tone and voice guidelines, make the texts across the documentation consistent and as clear as possible; for example using a conversational tone, using second person and active voice.
 
-For specific formatting, we follow the link:https://kubernetes.io/docs/contribute/style/style-guide/[Kubernetes documentation style guide]. The Stackable platform is built on Kubernetes and the documentation often refers to Kubernetes API objects, custom resources and snippets of resource specifications, as well as command line snippets to interact with Kubernetes clusters. How to format these in the documentation is covered in the Kubernetes documentation style guide.
+For specific formatting, follow the link:https://kubernetes.io/docs/contribute/style/style-guide/[Kubernetes documentation style guide]. The Stackable platform is built on Kubernetes and the documentation often refers to Kubernetes API objects, custom resources and snippets of resource specifications, as well as command line snippets to interact with Kubernetes clusters. How to format these in the documentation is covered in the Kubernetes documentation style guide. Some examples:
 
-// TODO link examples here
+- link:https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects[Use upper camel case for API objects] such as ConfigMap or KafkaCluster
+- link:https://kubernetes.io/docs/contribute/style/style-guide/#use-italics-to-define-or-introduce-new-terms[Use italics to define or introduce new terms]
+- link:https://kubernetes.io/docs/contribute/style/style-guide/#use-code-style-for-filenames-directories-and-paths[Use code style for filenames, directories and paths]
+- link:https://kubernetes.io/docs/contribute/style/style-guide/#use-code-style-for-object-field-names-and-namespaces[Use code style for object field names and namespaces]
+- link:https://kubernetes.io/docs/contribute/style/style-guide/#use-normal-style-for-string-and-integer-field-values[Use normal style for string and integer field values]
 
 For general formatting, language, grammar and tone guidelines we refer to the link:https://developers.google.com/style/[Google developer documentation style guide]. Some highlights:
 
@@ -23,7 +27,5 @@ For general formatting, language, grammar and tone guidelines we refer to the li
 - link:https://developers.google.com/style/capitalization[Use sentence case for headings]
 
 The Google guide also includes it's own list of link:https://developers.google.com/style/highlights[highlights].
-
-// TODO link examples here
 
 Lastly, these are guidelines and not strict rules to follow. Use your own judgement to clearly communicate and explain - after all this is what documentation is about.

--- a/modules/contributor/pages/style_guide.adoc
+++ b/modules/contributor/pages/style_guide.adoc
@@ -9,6 +9,21 @@
 // probably not to be done for now (even though it would be nice to have)
 // it sucks a bit to have the style guide a bit in a vacuum, but I think for now it would be fine. I could make a ticket for writing "How to contribute docs"
 
-For consistency and clarity, we provide some guidelines on how to write documentation.
+This page provides guidelines on how to write documentation for the Stackable platform. Style guidelines are provided specifying things such as capitalization rules, which format to use for emphasis or how API objects and other components should be styled in the documentation - formatting and "superficial" aspects of text. There are also guidelines on grammar, tone and voice, making the texts across the documentation consistent and as clear as possible; for example using a conversational tone, using second person and using active voice.
 
-We follow the link:https://kubernetes.io/docs/contribute/style/style-guide/[Kubernetes documentation style guide] and the link:https://developers.google.com/style/[Google developer documentation style guide].
+For specific formatting, we follow the link:https://kubernetes.io/docs/contribute/style/style-guide/[Kubernetes documentation style guide]. The Stackable platform is built on Kubernetes and the documentation often refers to Kubernetes API objects, custom resources and snippets of resource specifications, as well as command line snippets to interact with Kubernetes clusters. How to format these in the documentation is covered in the Kubernetes documentation style guide.
+
+// TODO link examples here
+
+For general formatting, language, grammar and tone guidelines we refer to the link:https://developers.google.com/style/[Google developer documentation style guide]. Some highlights:
+
+- link:https://developers.google.com/style/tone[Be conversational and friendly]
+- link:https://developers.google.com/style/person[Use second person]: "You" rather than "we"
+- link:https://developers.google.com/style/voice[Use active voice]
+- link:https://developers.google.com/style/capitalization[Use sentence case for headings]
+
+The Google guide also includes it's own list of link:https://developers.google.com/style/highlights[highlights].
+
+// TODO link examples here
+
+Lastly, these are guidelines and not strict rules to follow. Use your own judgement to clearly communicate and explain - after all this is what documentation is about.


### PR DESCRIPTION
closes #183 

This PR adds a page to the contributors guide about documentation style. It is brief, linking to the k8s and google docs, with some specific aspects mentioned explicitly.

The document is also linked in the menu and in the step-by-step guide in the section on contributing documentation.