### PR TITLE
Enable 'stable' URLs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -4,6 +4,11 @@ site:
   url: https://docs.stackable.tech
   robots: allow
 
+urls:
+  # This replaces the component version in the URL of the latest stable version with 'stable'
+  # i.e. /commons-operator/stable/index.html instead of /commons-operator/0.3/index.html
+  latest_version_segment: stable
+
 content:
   sources: 
     - url: https://github.com/stackabletech/documentation.git
@@ -55,6 +60,7 @@ content:
     - url: https://github.com/stackabletech/zookeeper-operator.git
       branches: main
       start_path: docs
+
 
 ui:
   bundle:

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -5,6 +5,11 @@ site:
   start_page: home::index.adoc
   robots: allow
 
+urls:
+  # This replaces the component version in the URL of the latest stable version with 'stable'
+  # i.e. /commons-operator/stable/index.html instead of /commons-operator/0.3/index.html
+  latest_version_segment: stable
+
 content:
   sources: 
     - url: ./
@@ -19,6 +24,7 @@ content:
 
     - url: https://github.com/stackabletech/airflow-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
     - url: https://github.com/stackabletech/druid-operator.git
       branches: main

--- a/supplemental-ui/partials/navbar.hbs
+++ b/supplemental-ui/partials/navbar.hbs
@@ -5,7 +5,7 @@
     Operators
     <div class="drop-down-content">
     <a class="drop-down-item" href="{{{ relativize "/home/operators/index.html" }}}">Overview</a>
-    <a class="drop-down-item" href="{{{ relativize "/airflow/nightly/index.html" }}}">Apache Airflow</a>
+    <a class="drop-down-item" href="{{{ relativize "/airflow/stable/index.html" }}}">Apache Airflow</a>
     <a class="drop-down-item" href="{{{ relativize "/druid/nightly/index.html" }}}">Apache Druid</a>
     <a class="drop-down-item" href="{{{ relativize "/hbase/nightly/index.html" }}}">Apache HBase</a>
     <a class="drop-down-item" href="{{{ relativize "/hdfs/nightly/index.html" }}}">Apache Hadoop HDFS</a>
@@ -18,7 +18,7 @@
     <a class="drop-down-item" href="{{{ relativize "/trino/nightly/index.html" }}}">Trino</a>
     <a class="drop-down-item" href="{{{ relativize "/zookeeper/nightly/index.html" }}}">Apache ZooKeeper</a>
     <a class="drop-down-item" href="{{{ relativize "/opa/nightly/index.html" }}}">OpenPolicyAgent</a>
-    <a class="drop-down-item" href="{{{ relativize "/commons-operator/nightly/index.html" }}}">Commons</a>
+    <a class="drop-down-item" href="{{{ relativize "/commons-operator/stable/index.html" }}}">Commons</a>
     <a class="drop-down-item" href="{{{ relativize "/secret-operator/nightly/index.html" }}}">Secret</a>
     </div>
 </div>


### PR DESCRIPTION
This is also related to #156 

This change enables a 'stable' url which points to the latest stable version of a documentation component. For example:
https://docs.stackable.tech/airflow/stable/index.html instead of https://docs.stackable.tech/airflow/0.3/index.html

closes #198 