### PR TITLE
Add instructions for using stackablectl instead of Helm

### DIFF
--- a/modules/ROOT/pages/getting_started.adoc
+++ b/modules/ROOT/pages/getting_started.adoc
@@ -74,30 +74,32 @@ CoreDNS is running at https://127.0.0.1:6443/api/v1/namespaces/kube-system/servi
 Metrics-server is running at https://127.0.0.1:6443/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
 ----
 
-=== Installing Helm
-Stackable uses https://helm.sh/[Helm] as the package manager for its Kubernetes operators. This greatly simplifies the deployment and management of Kubernetes operators and CRDs. The quickest way to install Helm is to run the following command:
+== Installing Stackable
+=== Install stackablectl
+
+Install the Stackable command line utility xref:stackablectl::index.adoc[stackablectl] by following the installation steps for your platform on the xref:stackablectl::installation.adoc[installation] page.
+
+=== Installing Stackable Operators
+The Stackable operators are components that translate the service definitions deployed via Kubernetes into deploy services on the worker nodes. These can be installed on any node that has access to the Kubernetes control plane. In this example we will install them on the controller node.
+
+Stackable operators are installed using stackablectl. Run the following commands to install the latest operator versions of ZooKeeper, Kafka and NiFi.
 
 [source,bash]
 ----
-curl -sfL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | /bin/bash -
+stackablectl operator install zookeeper secret nifi kafka
 ----
 
-
-== Installing Stackable
-=== Install Stackable Helm Repositories
-With Helm installed you can add the Stackable operator repo, where the helm charts to install Stackable operators can be found. There are development, test and a stable repositories available, we'll be using the stable repo in this guide.
+.Using Helm instead
+[%collapsible]
+====
+Add the stackable-stable Helm Chart repository:
 
 [source,bash]
 ----
 helm repo add stackable-stable https://repo.stackable.tech/repository/helm-stable/
 ----
 
-=== Installing Stackable Operators
-The Stackable operators are components that translate the service definitions deployed via Kubernetes into deploy services on the worker nodes. These can be installed on any node that has access to the Kubernetes control plane. In this example we will install them on the controller node.
-
-Stackable operators are installed using Helm charts. Run the following commands to install the operators for ZooKeeper, Kafka and NiFi using the repo configured earlier. The --devel flag will choose the latest available version; alternatively the --version flag can be used to deploy a specific version.
-
-==== Install operators from the Stackable repository
+Install the operators:
 
 [source,bash]
 ----
@@ -106,15 +108,16 @@ helm install kafka-operator stackable-stable/kafka-operator --version=0.5.0
 helm install secret-operator stackable-stable/secret-operator --version=0.2.0
 helm install nifi-operator stackable-stable/nifi-operator --version=0.5.0
 ----
+====
 
-You can check which operators are installed using `helm list`:
+You can check which operators are installed using `stackablectl operator installed`:
 
 ----
-NAME              	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART                   	APP VERSION
-kafka-operator    	default  	1       	2022-02-15 08:17:26.84659409 +0000 UTC 	deployed	kafka-operator-0.5.0    	0.5.0
-nifi-operator     	default  	1       	2022-02-15 08:17:37.93720808 +0000 UTC 	deployed	nifi-operator-0.5.0     	0.5.0
-secret-operator   	default  	1       	2022-02-15 08:17:32.700301793 +0000 UTC	deployed	secret-operator-0.2.0   	0.2.0
-zookeeper-operator	default  	1       	2022-02-15 08:17:17.893844595 +0000 UTC	deployed	zookeeper-operator-0.9.0	0.9.0
+OPERATOR              VERSION         NAMESPACE      STATUS           LAST UPDATED
+kafka                 0.6.0-nightly   default        deployed         2022-06-16 13:51:05.661282811 +0200 CEST
+nifi                  0.6.0-nightly   default        deployed         2022-06-20 16:22:45.985504689 +0200 CEST
+secret                0.5.0-nightly   default        deployed         2022-06-20 16:07:40.248027167 +0200 CEST
+zookeeper             0.10.0-nightly  default        deployed         2022-06-16 13:50:51.497813301 +0200 CEST
 ----
 
 == Deploying Stackable Services

--- a/modules/tutorials/pages/end-to-end_data_pipeline_example.adoc
+++ b/modules/tutorials/pages/end-to-end_data_pipeline_example.adoc
@@ -13,13 +13,9 @@ You should make sure that you have everything you need:
 
 * A running Kubernetes cluster
 * https://kubernetes.io/docs/tasks/tools/#kubectl[Kubectl] to interact with the cluster
-* https://helm.sh/[Helm] to deploy Operators and some dependencies
+* xref:stackablectl::installation.adoc[stackablectl] to install and interact with Stackable operators
+* https://helm.sh/[Helm] to deploy third-party dependencies
 * Shell utilities like `cat` and `curl`
-
-Throughout the tutorial you will install Operators from the Stackable Helm repository using Helm. To easily install from the Stackable repository, add a link to it to your Helm repository list:
-
-[source,bash]
-helm repo add stackable-stable https://repo.stackable.tech/repository/helm-stable/
 
 == Nifi and Kafka
 
@@ -36,7 +32,7 @@ The xref:secret-operator::index.adoc[Secret Operator] is needed by the Stackable
 The necessary certificates and keys for this are provided by the Secret Operator to the NiFi Pods.
 
 [source,bash]
-helm install secret-operator stackable-stable/secret-operator
+stackablectl operator install secret
 
 ==== ZooKeeper Operator
 
@@ -44,14 +40,14 @@ Apache NiFi and Apache Kafka both use Apache ZooKeeper as backing config storage
 There is no need to install multiple ZooKeeper clusters, as NiFi, Kafka and Druid can share the same cluster via provisioning a ZNode per backed service.
 
 [source,bash]
-helm install zookeeper-operator stackable-stable/zookeeper-operator
+stackablectl operator install zookeeper
 
 ==== Kafka Operator
 
 NiFi publishes the individual records from the S3 data to Kafka.
 
 [source,bash]
-helm install kafka-operator stackable-stable/kafka-operator
+stackablectl operator install kafka
 
 ==== NiFi Operator
 
@@ -59,7 +55,7 @@ NiFi is an ETL tool which will be used to model the dataflow of downloading and 
 It will also be used to convert the file content from CSV to JSON.
 
 [source,bash]
-helm install --repo https://repo.stackable.tech/repository/helm-dev nifi-operator nifi-operator --version=0.6.0-nightly
+stackablectl operator install nifi=0.6.0-nightly
 
 === Deploying Kafka and NiFi
 
@@ -259,7 +255,7 @@ You will set up the Operator and some dependencies, provision a Druid cluster an
 Like the other Operators, the Druid Operator is easily installed with Helm:
 
 [source,bash]
-helm install druid-operator stackable-stable/druid-operator
+stackablectl operator install druid
 
 
 === Set up dependencies
@@ -508,7 +504,7 @@ To analyze the data in Druid, the steps below explain how you can connect a Supe
 As before, you need to install the Operator:
 
 [source, bash]
-helm install superset-operator stackable-stable/superset-operator
+stackablectl operator install superset
 
 === Set up dependencies
 

--- a/modules/tutorials/pages/end-to-end_data_pipeline_example.adoc
+++ b/modules/tutorials/pages/end-to-end_data_pipeline_example.adoc
@@ -13,8 +13,21 @@ You should make sure that you have everything you need:
 
 * A running Kubernetes cluster
 * https://kubernetes.io/docs/tasks/tools/#kubectl[Kubectl] to interact with the cluster
-* xref:stackablectl::installation.adoc[stackablectl] to install and interact with Stackable operators
 * https://helm.sh/[Helm] to deploy third-party dependencies
+* xref:stackablectl::installation.adoc[stackablectl] to install and interact with Stackable operators
++
+[NOTE]
+====
+While we recommend to use stackablectl, you can also install operators from the Helm Chart repository:
+
+[source,bash]
+----
+helm repo add stackable-stable https://repo.stackable.tech/repository/helm-stable/
+----
+
+Instructions for installing via Helm are also provided throughout the tutorial.
+
+====
 * Shell utilities like `cat` and `curl`
 
 == Nifi and Kafka
@@ -34,6 +47,15 @@ The necessary certificates and keys for this are provided by the Secret Operator
 [source,bash]
 stackablectl operator install secret
 
+.Using Helm instead
+[%collapsible]
+====
+[source,bash]
+----
+helm install secret-operator stackable-stable/secret-operator
+----
+====
+
 ==== ZooKeeper Operator
 
 Apache NiFi and Apache Kafka both use Apache ZooKeeper as backing config storage, so the xref:zookeeper::index.adoc[Stackable Operator for Apache ZooKeeper] has to be installed in order to make sure that a ZooKeeper cluster can be rolled out.
@@ -42,12 +64,30 @@ There is no need to install multiple ZooKeeper clusters, as NiFi, Kafka and Drui
 [source,bash]
 stackablectl operator install zookeeper
 
+.Using Helm instead
+[%collapsible]
+====
+[source,bash]
+----
+helm install zookeeper-operator stackable-stable/zookeeper-operator
+----
+====
+
 ==== Kafka Operator
 
 NiFi publishes the individual records from the S3 data to Kafka.
 
 [source,bash]
 stackablectl operator install kafka
+
+.Using Helm instead
+[%collapsible]
+====
+[source,bash]
+----
+helm install zookeeper-operator stackable-stable/kafka-operator
+----
+====
 
 ==== NiFi Operator
 
@@ -56,6 +96,15 @@ It will also be used to convert the file content from CSV to JSON.
 
 [source,bash]
 stackablectl operator install nifi=0.6.0-nightly
+
+.Using Helm instead
+[%collapsible]
+====
+[source,bash]
+----
+helm install --repo https://repo.stackable.tech/repository/helm-dev nifi-operator nifi-operator --version=0.6.0-nightly
+----
+====
 
 === Deploying Kafka and NiFi
 
@@ -257,6 +306,14 @@ Like the other Operators, the Druid Operator is easily installed with Helm:
 [source,bash]
 stackablectl operator install druid
 
+.Using Helm instead
+[%collapsible]
+====
+[source,bash]
+----
+helm install druid-operator stackable-stable/druid-operator
+----
+====
 
 === Set up dependencies
 
@@ -505,6 +562,15 @@ As before, you need to install the Operator:
 
 [source, bash]
 stackablectl operator install superset
+
+.Using Helm instead
+[%collapsible]
+====
+[source,bash]
+----
+helm install druid-operator stackable-stable/superset-operator
+----
+====
 
 === Set up dependencies
 


### PR DESCRIPTION
We want to promote the use of stackablectl. This PR adds the instructions for using it to the Getting started guide as well as the Tutorial. The Helm alternative is still provided.