### PR TITLE
Removed spark standalone everywhere

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -60,10 +60,6 @@ content:
       branches: main
       tags: docs/*
       start_path: docs
-    - url: https://github.com/stackabletech/spark-operator.git
-      branches: main
-      tags: docs/*
-      start_path: docs
     - url: https://github.com/stackabletech/spark-k8s-operator.git
       branches: main
       tags: docs/*

--- a/gitpod-antora-playbook.yml
+++ b/gitpod-antora-playbook.yml
@@ -4,56 +4,77 @@ site:
   url: https://docs.stackable.tech
   robots: allow
 
+urls:
+  # This replaces the component version in the URL of the latest stable version with 'stable'
+  # i.e. /commons-operator/stable/index.html instead of /commons-operator/0.3/index.html
+  latest_version_segment: stable
+
 content:
   sources: 
     - url: /workspace/documentation
       branches: HEAD
 
+    - url: https://github.com/stackabletech/stackablectl.git
+      branches: main
+      tags: docs/*
+      start_path: docs
+
     - url: https://github.com/stackabletech/commons-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
     - url: https://github.com/stackabletech/secret-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
 
     - url: https://github.com/stackabletech/airflow-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
     - url: https://github.com/stackabletech/druid-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
     - url: https://github.com/stackabletech/hbase-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
     - url: https://github.com/stackabletech/hdfs-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
     - url: https://github.com/stackabletech/hive-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
     - url: https://github.com/stackabletech/kafka-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
     - url: https://github.com/stackabletech/nifi-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
     - url: https://github.com/stackabletech/opa-operator.git
       branches: main
-      start_path: docs
-    - url: https://github.com/stackabletech/spark-operator.git
-      branches: main
+      tags: docs/*
       start_path: docs
     - url: https://github.com/stackabletech/spark-k8s-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
     - url: https://github.com/stackabletech/superset-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
     - url: https://github.com/stackabletech/trino-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
     - url: https://github.com/stackabletech/zookeeper-operator.git
       branches: main
+      tags: docs/*
       start_path: docs
 
 ui:
@@ -64,6 +85,7 @@ ui:
 antora:
   extensions:
     - '@antora/lunr-extension'
+    - asciidoctor-kroki
 
 asciidoc:
   attributes:

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -61,10 +61,6 @@ content:
       branches: main
       tags: docs/*
       start_path: docs
-    - url: https://github.com/stackabletech/spark-operator.git
-      branches: main
-      tags: docs/*
-      start_path: docs
     - url: https://github.com/stackabletech/spark-k8s-operator.git
       branches: main
       tags: docs/*

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -112,7 +112,7 @@ xref:druid::index.adoc[Read more]
 <h3>Apache HBase</h3>
 ++++
 
-HBase is a distributed, scalable, big data store
+HBase is a distributed, scalable, big data store.
 
 xref:hbase::index.adoc[Read more]
 
@@ -194,11 +194,7 @@ xref:nifi::index.adoc[Read more]
 
 Apache Spark is a multi-language engine for executing data engineering, data science, and machine learning on single-node machines or clusters.
 
-Stackable offers two different operators for managing Apache Spark clusters. One for multi-tenancy or standalone clusters and one for isolated workloads.
-
-xref:spark::index.adoc[Read more] for more information on how to run a multi-tenancy Spark clusters with Stackable.
-
-For more information on how to run isolated Spark workloads with Stackable operators xref:spark-k8s::index.adoc[see here].
+xref:spark-k8s::index.adoc[Read more]
 
 ++++
 </div>
@@ -212,7 +208,7 @@ For more information on how to run isolated Spark workloads with Stackable opera
 <h3>Apache Superset</h3>
 ++++
 
-Apache Superset is a modern data exploration and visualization platform
+Apache Superset is a modern data exploration and visualization platform.
 
 xref:superset::index.adoc[Read more]
 

--- a/modules/contributor/pages/development_dashboard.adoc
+++ b/modules/contributor/pages/development_dashboard.adoc
@@ -68,15 +68,6 @@ This page contains information about our products and relevant links you might n
 |https://docs.stackable.tech/nifi/index.html
 |
 
-|Apache Spark (standalone)
-|https://spark.apache.org/
-|https://github.com/apache/spark
-|https://github.com/stackabletech/spark-operator
-|https://github.com/stackabletech/docker-images/tree/main/spark
-|https://ci.stackable.tech/job/Spark%20Operator%20Integration%20Tests/
-|https://docs.stackable.tech/spark/index.html
-|
-
 |Apache Spark on Kubernetes
 |https://spark.apache.org/
 |https://github.com/apache/spark

--- a/modules/operators/pages/supported_versions.adoc
+++ b/modules/operators/pages/supported_versions.adoc
@@ -34,10 +34,6 @@ include::nifi::partial$supported-versions.adoc[]
 
 include::opa::partial$supported-versions.adoc[]
 
-== Apache Spark (standalone)
-
-include::spark::partial$supported-versions.adoc[]
-
 == Apache Spark on Kubernetes
 
 include::spark-k8s::partial$supported-versions.adoc[]

--- a/modules/operators/partials/operator_doc_links.adoc
+++ b/modules/operators/partials/operator_doc_links.adoc
@@ -5,7 +5,6 @@
 ** xref:hive::index.adoc[Apache Hive]
 ** xref:kafka::index.adoc[Apache Kafka]
 ** xref:nifi::index.adoc[Apache NiFi]
-** xref:spark::index.adoc[Apache Spark (standalone)]
 ** xref:spark-k8s::index.adoc[Apache Spark on K8S]
 ** xref:superset::index.adoc[Apache Superset]
 ** xref:trino::index.adoc[Trino]

--- a/supplemental-ui/partials/navbar.hbs
+++ b/supplemental-ui/partials/navbar.hbs
@@ -14,7 +14,6 @@
     <a class="drop-down-item" href="{{{ relativize "/hive/stable/index.html" }}}">Apache Hive</a>
     <a class="drop-down-item" href="{{{ relativize "/kafka/stable/index.html" }}}">Apache Kafka</a>
     <a class="drop-down-item" href="{{{ relativize "/nifi/stable/index.html" }}}">Apache NiFi</a>
-    <a class="drop-down-item" href="{{{ relativize "/spark/stable/index.html" }}}">Apache Spark (standalone)</a>
     <a class="drop-down-item" href="{{{ relativize "/spark-k8s/stable/index.html" }}}">Apache Spark on K8S</a>
     <a class="drop-down-item" href="{{{ relativize "/superset/stable/index.html" }}}">Apache Superset</a>
     <a class="drop-down-item" href="{{{ relativize "/trino/stable/index.html" }}}">Trino</a>


### PR DESCRIPTION
We are retiring the spark (standalone) operator (https://github.com/stackabletech/issues/issues/227) and part of that is removing the docs. This PR does that.