### PR TITLE
Added 'clean' target for makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
+cache/
 .idea/
 node_modules/

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,9 @@ build:
 	node_modules/.bin/gulp --cwd ui bundle
 	node_modules/.bin/antora generate $(PLAYBOOK) $(ANTORAFLAGS)
 
+clean:
+	rm -r build
+	# 'cache' is the configured cache dir in the playbook
+	rm -r cache
+
 .PHONY: build

--- a/README.adoc
+++ b/README.adoc
@@ -4,9 +4,9 @@
 :base-repo: https://github.com/stackabletech
 
 This is the main repository for the documentation of the Stackable platform.
-It uses https://antora.org[Antora].
+Have a look at the https://docs.stackable.tech/[live version].
 
-This repository hosts the Antora playbook file as well as some generic documentation modules.
+The documentation is built with https://antora.org[Antora]. This repository hosts the Antora playbook file as well as platform documentation. Other Stackable repos contain 'docs' directories which are pulled in by this repo.
 
 To build the site, pull submodules, install dependencies and run `make`:
 
@@ -17,7 +17,7 @@ $ npm ci
 $ make
 ----
 
-NOTE: Antora caches all resources it downloads in the user's cache directory (e.g. `~/.cache/antora` directory on Linux). It will _not_ automatically update those. Use the `--fetch` flag (`make ANTORAFLAGS=--fetch`) to update all sources.
+NOTE: Antora caches the external content repos in the cache directory (configured to be `./cache`). It will _not_ automatically update those.  Use the `--fetch` flag (`make ANTORAFLAGS=--fetch`) to update all sources, or use `make clean` to delete the `cache` and `build` directory.
 
 == Development
 

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -93,3 +93,9 @@ asciidoc:
     plantuml-server-url: http://www.plantuml.com/plantuml
   extensions:
     - asciidoctor-kroki
+
+# the default caching directory is ./.cache/antora
+# Antora caches the git repos, this can sometimes lead to stale content
+# use 'make clean' to remove the build and cache directory
+runtime:
+  cache_dir: ./cache

--- a/gitpod-antora-playbook.yml
+++ b/gitpod-antora-playbook.yml
@@ -93,3 +93,9 @@ asciidoc:
     plantuml-server-url: http://www.plantuml.com/plantuml
   extensions:
     - asciidoctor-kroki
+
+# the default caching directory is ./.cache/antora
+# Antora caches the git repos, this can sometimes lead to stale content
+# use 'make clean' to remove the build and cache directory
+runtime:
+  cache_dir: ./cache

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -95,3 +95,9 @@ asciidoc:
     kroki-fetch-diagram: true
   extensions:
     - asciidoctor-kroki
+
+# the default caching directory is ./.cache/antora
+# Antora caches the git repos, this can sometimes lead to stale content
+# use 'make clean' to remove the build and cache directory
+runtime:
+  cache_dir: ./cache


### PR DESCRIPTION
Fixes #226 

- Cache directory is configured to be local instead of in the user directory
- new 'clean' target that deletes the build and cache directory
- Updated readme