### PR TITLE
Added crossreferences between ADR018 and ADR023

### DIFF
--- a/modules/contributor/pages/adr/ADR018-product_image_versioning.adoc
+++ b/modules/contributor/pages/adr/ADR018-product_image_versioning.adoc
@@ -60,7 +60,7 @@ Based on the above, there are actually two decisions to take around this problem
 While these two questions are related to each other they can be decided fairly independently of each other.
 The decision process for _2._ will be influenced by the decision that is taken on _1._, so we will get this done first.
 
-This ADR will be limited to the question of how stackable image versions are created, with the question of how the operator derives the correct image to use deferred to a subsequent ADR.
+This ADR will be limited to the question of how stackable image versions are created, with the question of how the operator derives the correct image to use deferred to a subsequent ADR (see xref:adr/ADR023-product-image-selection.adoc[]).
 
 == Decision Drivers
 

--- a/modules/contributor/pages/adr/ADR023-product-image-selection.adoc
+++ b/modules/contributor/pages/adr/ADR023-product-image-selection.adoc
@@ -12,7 +12,7 @@ v0.1, 2022-08-31
 * Date: 2022-08-31
 
 == Context and Problem Statement
-Currently users have to specify the full image tag in the Products CRD.
+Currently users have to specify the full image tag in the Products CRD, as described in xref:adr/ADR018-product_image_versioning.adoc[].
 
 [source,yaml]
 ----


### PR DESCRIPTION
ADR018 and ADR023 are closely related to each other. In fact there has always bean a note in 018 that we will address part of it in a later ADR, which 023 now partially covers.

This PR simply adds cross references to both ADRs, so that someone who reads either one of them in isolation is aware of the other ADR that will be of interest too.