### PR TITLE
Added tracking keys

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -4,6 +4,8 @@ site:
   url: https://docs.stackable.tech
   start_page: home::index.adoc
   robots: allow
+  keys:
+    enable_tracking: true
 
 urls:
   # This replaces the component version in the URL of the latest stable version with 'stable'

--- a/gitpod-antora-playbook.yml
+++ b/gitpod-antora-playbook.yml
@@ -3,6 +3,8 @@ site:
   title: Stackable Documentation
   url: https://docs.stackable.tech
   robots: allow
+  keys:
+    enable_tracking: false
 
 urls:
   # This replaces the component version in the URL of the latest stable version with 'stable'

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -4,6 +4,8 @@ site:
   url: https://docs.stackable.tech
   start_page: home::index.adoc
   robots: allow
+  keys:
+    enable_tracking: false
 
 urls:
   # This replaces the component version in the URL of the latest stable version with 'stable'


### PR DESCRIPTION
Tracking site keys which are read by the documentation UI. Tracking is only enabled in the production playbook.