### PR TITLE
Search fix

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -87,7 +87,7 @@ The Stackable Data Platform supports the following products:
 ++++
 
 ++++
-<h3>Apache Airflow</h3>
+<h3 id="airflow"><a class="anchor" href="#airflow"></a>Apache Airflow</h3>
 ++++
 
 Airflow is a workflow engine and your replacement should you be using Apache Oozie.
@@ -103,7 +103,7 @@ xref:airflow::index.adoc[Read more]
 ++++
 
 ++++
-<h3>Apache Druid</h3>
+<h3 id="druid"><a class="anchor" href="#druid"></a>Apache Druid</h3>
 ++++
 
 Apache Druid is a real-time database to power modern analytics applications.
@@ -119,7 +119,7 @@ xref:druid::index.adoc[Read more]
 ++++
 
 ++++
-<h3>Apache HBase</h3>
+<h3 id="hbase"><a class="anchor" href="#hbase"></a>Apache HBase</h3>
 ++++
 
 HBase is a distributed, scalable, big data store.
@@ -135,7 +135,7 @@ xref:hbase::index.adoc[Read more]
 ++++
 
 ++++
-<h3>Apache Hadoop HDFS</h3>
+<h3 id="hdfs"><a class="anchor" href="#hdfs"></a>Apache Hadoop HDFS</h3>
 ++++
 
 HDFS is a distributed file system that provides high-throughput access to application data.
@@ -151,7 +151,7 @@ xref:hdfs::index.adoc[Read more]
 ++++
 
 ++++
-<h3>Apache Hive</h3>
+<h3 id="hive"><a class="anchor" href="#hive"></a>Apache Hive</h3>
 ++++
 
 The Apache Hive data warehouse software facilitates reading, writing, and managing large datasets residing in distributed storage using SQL. We support the Hive Metastore.
@@ -167,7 +167,7 @@ xref:hive::index.adoc[Read more]
 ++++
 
 ++++
-<h3>Apache Kafka</h3>
+<h3 id="kafka"><a class="anchor" href="#kafka"></a>Apache Kafka</h3>
 ++++
 
 Apache Kafka is an open-source distributed event streaming platform used by thousands of companies for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications.
@@ -183,7 +183,7 @@ xref:kafka::index.adoc[Read more]
 ++++
 
 ++++
-<h3>Apache NiFi</h3>
+<h3 id="nifi"><a class="anchor" href="#nifi"></a>Apache NiFi</h3>
 ++++
 
 An easy to use, powerful, and reliable system to process and distribute data.
@@ -199,7 +199,7 @@ xref:nifi::index.adoc[Read more]
 ++++
 
 ++++
-<h3>Apache Spark</h3>
+<h3 id="spark"><a class="anchor" href="#spark"></a>Apache Spark</h3>
 ++++
 
 Apache Spark is a multi-language engine for executing data engineering, data science, and machine learning on single-node machines or clusters.
@@ -215,7 +215,7 @@ xref:spark-k8s::index.adoc[Read more]
 ++++
 
 ++++
-<h3>Apache Superset</h3>
+<h3 id="superset"><a class="anchor" href="#superset"></a>Apache Superset</h3>
 ++++
 
 Apache Superset is a modern data exploration and visualization platform.
@@ -231,7 +231,7 @@ xref:superset::index.adoc[Read more]
 ++++
 
 ++++
-<h3>Trino</h3>
+<h3 id="trino"><a class="anchor" href="#trino"></a>Apache Trino</h3>
 ++++
 
 Fast distributed SQL query engine for big data analytics that helps you explore your data universe.
@@ -247,7 +247,7 @@ xref:trino::index.adoc[Read more]
 ++++
 
 ++++
-<h3>Apache ZooKeeper</h3>
+<h3 id="zookeeper"><a class="anchor" href="#zookeeper"></a>Apache ZooKeeper</h3>
 ++++
 
 ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.

--- a/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
+++ b/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
@@ -114,10 +114,30 @@ spec:
           ...
 ```
 
+**Override everything** - The customer should be able to supply their own configuration file. Where this is placed depends on the product.
+
+```
+logging:
+  custom:
+    configMap: nameOfMyConfigMapWithTheConfigFile
+```
+
+Setting the `custom` field will disable any configurations made in `file` and `stdout`.
+
+**Disable vector** - Vector should be optional, if the user wants to use their own logging system.
+
+```
+logging:
+  enableVectorAgent: false  # defaults to true
+```
+
+
 
 === Deploying the Stack
 
-TODO
+The operator deploys the Vector agent as a sidecar and deploys the logging configuration for the product.
+
+The aggregator and OpenSearch sink are deployed with Helm for now, with a plan to integrate this into stackablectl. _Maybe_ we build our own operators for Vector and OpenSearch in the future.
 
 == Consequences
 

--- a/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
+++ b/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
@@ -4,7 +4,15 @@ v0.1, 2022-10-26
 :status: [draft]
 
 * Status: {status}
-* Deciders: Stackable Team
+* Deciders:
+** Felix Hennig
+** Lars Francke
+** Malte Sander
+** Razvan Mihai
+** Sebastian Bernauer
+** Siegfried Weber
+** Sönke Liebau
+** Teo Klestrup Röijezon
 * Date: 2022-10-26
 
 Technical Story: https://github.com/stackabletech/issues/issues/202, https://github.com/stackabletech/issues/issues/261

--- a/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
+++ b/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
@@ -25,7 +25,7 @@ Product logs cannot be correlated to operator logs easily, we want to have both 
 * **transport security** - Logs should transmitted with encryption/TLS.
 * **custom overrides** - The log format, aggregator and sink should be substitutable by the user.
 
-== Considered Options
+== Decision
 
 === Log Aggregation Framework: Vector
 
@@ -36,37 +36,6 @@ https://vector.dev/[Vector] has been picked without comparison to other existing
 * Parse logs as they are (in plaintext) vs. provide custom structured logs (i.e. json/XML)
 * Retrieve logs from stdout vs. from file
 
-=== Log Aggregation Architecture
-
-* Agent: DaemonSet vs. Sidecar
-* Aggregator vs. no aggregator
-
-=== Log Sink: OpenSearch
-
-https://opensearch.org/[OpenSearch] has been picked as the sink for all the aggregated logs. No other opens have been considered, but as the sink sits at the very top of the chain, it is easy to swap it out for a different software.
-
-=== Logging configuration
-
-TODO
-
-== Decision Outcome
-
-We have already decided to use https://vector.dev/[Vector] as an aggregator. It looked good, no other options were evaluated.
-
-We chose to provide **plaintext logs on stdout** and **structured logs on file**. For the architecture, we chose to deploy the agent as a **sidecar** and **use an aggregator**. We chose to provide **OpenSearch** as a default Sink for logs.
-
-=== Positive Consequences
-
-* All logs can be accessed from a central placed, and logs for multiple products and operators can be correlated easily
-
-=== Negative Consequences
-
-* Sidecar deployment has more overhead than the DaemonSet deployment
-
-== Pros and Cons of the Options
-
-=== Plaintext vs. Structured Log; Stdout vs File
-
 * Logs on stdout are still useful, because you can read them with kubectl or k9s to debug things. In that case, they should be plain, so they are easy to read for a human.
 * Logs parsed by the aggregator are differt.
   * Parsing plaintext logs can be tricky, because regexes are needed
@@ -74,33 +43,32 @@ We chose to provide **plaintext logs on stdout** and **structured logs on file**
 * Some products _need_ to log to file, because of _reasons_. They either cannot be configured differently (which ones?), have logs confidential logs that shouldn't go do stdout, or ...
 * File logs can be structured, as they are not meant to be read by a human.
 
-=== Topology: Aggregator vs. no Aggregator
+=== Log Aggregation Architecture
+
+* Agent: DaemonSet vs. Sidecar
+* Aggregator vs. no aggregator
 
 Vector offers multiple https://vector.dev/docs/setup/deployment/topologies/[topologies] and already lists pros and cons.
 
 An aggregator makes it easier to configure a sink: only one place to configure it (the aggregator has "multi-host context" as Vector calls it).
 
-=== Agent roles: Sidecar vs. DaemonSet
 
 Vector offers multiple https://vector.dev/docs/setup/deployment/roles/#agent[roles] in which it can run.
 
 The DaemonSet is easier to deploy, and only one vector instance is running per host. But the sidecar has deeper integration with the product container and can read log files, something that we decided we need.
 
-=== Sinks
+=== Log Sink: OpenSearch
+
+https://opensearch.org/[OpenSearch] has been picked as the sink for all the aggregated logs. No other opens have been considered, but as the sink sits at the very top of the chain, it is easy to swap it out for a different software.
 
 We want to make it easy for users to deploy OpenSearch, but also easy to switch out the sink.
 
 (How and where is this configured, and how can we make it easy for the user?)
 
-== Links
+=== Logging configuration
 
-* https://vector.dev/[Vector]
-* https://vector.dev/docs/setup/deployment/roles/[Vector Deployment Roles]
-* https://vector.dev/docs/setup/deployment/topologies/[Vector Deployment Topologies]
+TODO
 
----
-
-== Notes on CRD Fragment
 Configuration requirements
 
 * stdout and files should have different log levels
@@ -125,11 +93,35 @@ spec:
         level: INFO
 ```
 
-What should be the default level? WARN? INFO?
+
+=== Deploying the Stack
+
+Our Oper
+
+== Decision Outcome - Summary
+
+We have already decided to use https://vector.dev/[Vector] as an aggregator. It looked good, no other options were evaluated.
+
+We chose to provide **plaintext logs on stdout** and **structured logs on file**. For the architecture, we chose to deploy the agent as a **sidecar** and **use an aggregator**. We chose to provide **OpenSearch** as a default Sink for logs.
+
+== Consequences
+
+=== Positive
+
+* All logs can be accessed from a central placed, and logs for multiple products and operators can be correlated easily
+
+=== Negative
+
+* Sidecar deployment has more overhead than the DaemonSet deployment
 
 
+== Links
 
+* https://vector.dev/[Vector]
+* https://vector.dev/docs/setup/deployment/roles/[Vector Deployment Roles]
+* https://vector.dev/docs/setup/deployment/topologies/[Vector Deployment Topologies]
 
+== Open Questions
 
-
-what if we change log levels while the pod is running?
+* What should be the default level? WARN? INFO?
+* What if we change log levels while the pod is running?

--- a/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
+++ b/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
@@ -21,6 +21,7 @@ Product logs cannot be correlated to operator logs easily, we want to have both 
 
 * **identical configuration** - All product logs should be configurable in the same way, no matter their underlying logging framework (log4j, logback, Python logging, etc.). Every product should have a logging section in its CRD.
 * **easily configured sinks** - A log sink (i.e. elasticsearch) should only be configured in a single place for the whole platform (not in every product instance).
+* **Support plaintext logs on stdout** - It is a Kubernetes convention to log in plaintext to stdout. This should be kept, as it is a useful tool for debugging.
 * **custom overrides** - The log format, aggregator and sink should be substitutable by the user.
 * **transport security** - Logs should transmitted with encryption/TLS.
 

--- a/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
+++ b/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
@@ -27,16 +27,27 @@ Product logs cannot be correlated to operator logs easily, we want to have both 
 
 == Considered Options
 
-=== Log Retrieval
+=== Log Aggregation Framework: Vector
 
-* Parse plaintext vs. provide structured logs (i.e. json)
+https://vector.dev/[Vector] has been picked without comparison to other existing choices. Some googling shows https://medium.com/ibm-cloud/log-collectors-performance-benchmarking-8c5218a08fea[Vector has better performance than fluentd], the biggest name in this space. Vector is also open source and written in Rust: https://github.com/vectordotdev/vector[GitHub].
+
+=== Log Retrieval Strategy
+
+* Parse logs as they are (in plaintext) vs. provide custom structured logs (i.e. json/XML)
 * Retrieve logs from stdout vs. from file
 
 === Log Aggregation Architecture
 
+* Agent: DaemonSet vs. Sidecar
 * Aggregator vs. no aggregator
-* DaemonSet vs. Sidecar
-* Sink: OpenSearch vs. ???
+
+=== Log Sink: OpenSearch
+
+https://opensearch.org/[OpenSearch] has been picked as the sink for all the aggregated logs. No other opens have been considered, but as the sink sits at the very top of the chain, it is easy to swap it out for a different software.
+
+=== Logging configuration
+
+TODO
 
 == Decision Outcome
 
@@ -44,15 +55,13 @@ We have already decided to use https://vector.dev/[Vector] as an aggregator. It 
 
 We chose to provide **plaintext logs on stdout** and **structured logs on file**. For the architecture, we chose to deploy the agent as a **sidecar** and **use an aggregator**. We chose to provide **OpenSearch** as a default Sink for logs.
 
-=== Positive Consequences <!-- optional -->
+=== Positive Consequences
 
-* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
-* …
+* All logs can be accessed from a central placed, and logs for multiple products and operators can be correlated easily
 
-=== Negative Consequences <!-- optional -->
+=== Negative Consequences
 
-* [e.g., compromising quality attribute, follow-up decisions required, …]
-* …
+* Sidecar deployment has more overhead than the DaemonSet deployment
 
 == Pros and Cons of the Options
 
@@ -65,40 +74,31 @@ We chose to provide **plaintext logs on stdout** and **structured logs on file**
 * Some products _need_ to log to file, because of _reasons_. They either cannot be configured differently (which ones?), have logs confidential logs that shouldn't go do stdout, or ...
 * File logs can be structured, as they are not meant to be read by a human.
 
-=== Aggregator vs. no Aggregator
+=== Topology: Aggregator vs. no Aggregator
 
-[example | description | pointer to more information | …] <!-- optional -->
+Vector offers multiple https://vector.dev/docs/setup/deployment/topologies/[topologies] and already lists pros and cons.
 
-* Good, because [argument a]
-* Good, because [argument b]
-* Bad, because [argument c]
-* … <!-- numbers of pros and cons can vary -->
+An aggregator makes it easier to configure a sink: only one place to configure it (the aggregator has "multi-host context" as Vector calls it).
 
-=== Sidecar vs. DaemonSet
+=== Agent roles: Sidecar vs. DaemonSet
 
-[example | description | pointer to more information | …] <!-- optional -->
+Vector offers multiple https://vector.dev/docs/setup/deployment/roles/#agent[roles] in which it can run.
 
-* Good, because [argument a]
-* Good, because [argument b]
-* Bad, because [argument c]
-* … <!-- numbers of pros and cons can vary -->
+The DaemonSet is easier to deploy, and only one vector instance is running per host. But the sidecar has deeper integration with the product container and can read log files, something that we decided we need.
 
 === Sinks
 
-[example | description | pointer to more information | …] <!-- optional -->
+We want to make it easy for users to deploy OpenSearch, but also easy to switch out the sink.
 
-* Good, because [argument a]
-* Good, because [argument b]
-* Bad, because [argument c]
-* … <!-- numbers of pros and cons can vary -->
+(How and where is this configured, and how can we make it easy for the user?)
 
-== Links <!-- optional -->
+== Links
 
-* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
-* … <!-- numbers of links can vary -->
+* https://vector.dev/[Vector]
+* https://vector.dev/docs/setup/deployment/roles/[Vector Deployment Roles]
+* https://vector.dev/docs/setup/deployment/topologies/[Vector Deployment Topologies]
 
-
-
+---
 
 == Notes on CRD Fragment
 Configuration requirements

--- a/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
+++ b/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
@@ -11,26 +11,38 @@ Technical Story: https://github.com/stackabletech/issues/issues/202, https://git
 
 == Context and Problem Statement
 
-// [Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+// Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.
 
-How can we aggregate logs from all products?
+Context: As of the day of writing, every product logs in its own log format to stdout. Logs cannot be viewed centrally, log levels cannot be set for individual parts of applications or across multiple products at once.
 
-== Decision Drivers <!-- optional -->
+// TODO: Are operator logs out of scope or in scope?
 
-* [driver 1, e.g., a force, facing concern, …]
-* [driver 2, e.g., a force, facing concern, …]
-* … <!-- numbers of drivers can vary -->
+== Decision Drivers
+
+* **identical configuration** - All product logs should be configurable in the same way, no matter their underlying logging framework (log4j, logback, Python logging, etc.).
+// TODO: Open question: Which properties do we support?
+* **easily configured sinks** - A log sink (i.e. elasticsearch) should only be configured in a single place for the whole platform (not in every product instance).
+* **transport security** - Logs should transmitted with encryption/TLS.
+* **custom overrides** - The log format, aggregator and sink should be substitutable by the user.
 
 == Considered Options
 
-* [option 1]
-* [option 2]
-* [option 3]
-* … <!-- numbers of options can vary -->
+// TODO: Why vector?
+
+=== Log Retrieval
+
+* Parse plaintext vs. provide structured logs (i.e. json)
+* Retrieve logs from stdout vs. from file
+
+=== Log Aggregation Architecture
+
+* Aggregator vs. no aggregator
+* DaemonSet vs. Sidecar
+* Sink: OpenSearch vs. ???
 
 == Decision Outcome
 
-Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+We chose to provide **plaintext logs on stdout** and *structured logs on file**. For the architecture, we chose to deploy the agent as a **sidecar** and **use an aggregator**. We chose to provide **OpenSearch** as a default Sink for logs.
 
 === Positive Consequences <!-- optional -->
 
@@ -42,9 +54,18 @@ Chosen option: "[option 1]", because [justification. e.g., only option, which me
 * [e.g., compromising quality attribute, follow-up decisions required, …]
 * …
 
-== Pros and Cons of the Options <!-- optional -->
+== Pros and Cons of the Options
 
-=== [option 1]
+=== Plaintext vs. Structured Log; Stdout vs File
+
+* Logs on stdout are still useful, because you can read them with kubectl or k9s to debug things. In that case, they should be plain, so they are easy to read for a human.
+* Logs parsed by the aggregator are differt.
+  * Parsing plaintext logs can be tricky, because regexes are needed
+  * Using structured logs is much more robust.
+* Some products _need_ to log to file, because of _reasons_. They either cannot be configured differently (which ones?), have logs confidential logs that shouldn't go do stdout, or ...
+* File logs can be structured, as they are not meant to be read by a human.
+
+=== Aggregator vs. no Aggregator
 
 [example | description | pointer to more information | …] <!-- optional -->
 
@@ -53,7 +74,7 @@ Chosen option: "[option 1]", because [justification. e.g., only option, which me
 * Bad, because [argument c]
 * … <!-- numbers of pros and cons can vary -->
 
-=== [option 2]
+=== Sidecar vs. DaemonSet
 
 [example | description | pointer to more information | …] <!-- optional -->
 
@@ -62,7 +83,7 @@ Chosen option: "[option 1]", because [justification. e.g., only option, which me
 * Bad, because [argument c]
 * … <!-- numbers of pros and cons can vary -->
 
-=== [option 3]
+=== Sinks
 
 [example | description | pointer to more information | …] <!-- optional -->
 

--- a/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
+++ b/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
@@ -19,11 +19,18 @@ Product logs cannot be correlated to operator logs easily, we want to have both 
 
 == Decision Drivers
 
-* **identical configuration** - All product logs should be configurable in the same way, no matter their underlying logging framework (log4j, logback, Python logging, etc.).
-// TODO: Open question: Which properties do we support?
+* **identical configuration** - All product logs should be configurable in the same way, no matter their underlying logging framework (log4j, logback, Python logging, etc.). Every product should have a logging section in its CRD.
 * **easily configured sinks** - A log sink (i.e. elasticsearch) should only be configured in a single place for the whole platform (not in every product instance).
-* **transport security** - Logs should transmitted with encryption/TLS.
 * **custom overrides** - The log format, aggregator and sink should be substitutable by the user.
+* **transport security** - Logs should transmitted with encryption/TLS.
+
+=== Assumptions
+
+* **RegEx parsing is error prone** - Parsing pure string log output to get structure (time, module, log level, message, ...) is prone to errors. Especially for multi-line messages like stacktraces. The design should use structured log ouput whenever possible.
+
+=== Constraints
+
+* **Multiple files** - Some products like HDFS _need_ to log to (multiple) files, so parsing just stdout is not sufficient; we need to parse files.
 
 == Decision
 
@@ -39,6 +46,8 @@ https://vector.dev/[Vector] has been picked without comparison to other existing
 
 === Log Retrieval Strategy
 
+
+
 * Parse logs as they are (in plaintext) vs. provide custom structured logs (i.e. json/XML)
 * Retrieve logs from stdout vs. from file
 
@@ -51,17 +60,9 @@ https://vector.dev/[Vector] has been picked without comparison to other existing
 
 === Log Aggregation Architecture
 
-* Agent: DaemonSet vs. Sidecar
-* Aggregator vs. no aggregator
+**Topology** - Vector offers multiple https://vector.dev/docs/setup/deployment/topologies/[topologies] and already lists pros and cons. An aggregator makes it easier to configure a sink: only one place to configure it (the aggregator has "multi-host context" as Vector calls it).
 
-Vector offers multiple https://vector.dev/docs/setup/deployment/topologies/[topologies] and already lists pros and cons.
-
-An aggregator makes it easier to configure a sink: only one place to configure it (the aggregator has "multi-host context" as Vector calls it).
-
-
-Vector offers multiple https://vector.dev/docs/setup/deployment/roles/#agent[roles] in which it can run.
-
-The DaemonSet is easier to deploy, and only one vector instance is running per host. But the sidecar has deeper integration with the product container and can read log files, something that we decided we need.
+**Agent role** - Vector offers multiple https://vector.dev/docs/setup/deployment/roles/#agent[roles] in which it can run. The DaemonSet is easier to deploy, and only one vector instance is running per host. But the sidecar has deeper integration with the product container and can read log files, something that we decided we need.
 
 === Log Sink: OpenSearch
 

--- a/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
+++ b/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
@@ -27,6 +27,12 @@ Product logs cannot be correlated to operator logs easily, we want to have both 
 
 == Decision
 
+We decided to use https://vector.dev/[Vector] as an aggregator. It looked good, no other options were evaluated.
+
+We chose to provide **plaintext logs on stdout** and **structured logs on file**. For the architecture, we chose to deploy the agent as a **sidecar** and **use an aggregator**. We chose to provide **OpenSearch** as a default Sink for logs.
+
+Find detailed considerations below.
+
 === Log Aggregation Framework: Vector
 
 https://vector.dev/[Vector] has been picked without comparison to other existing choices. Some googling shows https://medium.com/ibm-cloud/log-collectors-performance-benchmarking-8c5218a08fea[Vector has better performance than fluentd], the biggest name in this space. Vector is also open source and written in Rust: https://github.com/vectordotdev/vector[GitHub].
@@ -67,42 +73,51 @@ We want to make it easy for users to deploy OpenSearch, but also easy to switch 
 
 === Logging configuration
 
-TODO
+**Log levels** - It is common to have four or five log levels: Error, Warning, Info, Debug and - optionally - Trace. We want to support them across all products.
 
-Configuration requirements
+**stdout vs. file** - We want to have different log levels (and possibly other settings) for stdout and file output. This makes debugging easier, without also filling up the log aggregator with very chatty logs.
 
-* stdout and files should have different log levels
-* different packages/components should have different log levels
+**Settings per logger** - Most products (especially Java based ones) support setting a log level per package. We also want to support this in our CRD.
 
+```
+logging:
+  file:
+    loggers:
+      ROOT:
+        level: INFO
+      some.interesting.module:
+        level: DEBUG
+  stdout:
+    loggers:
+      ROOT:
+        level: DEBUG
+      my.specific.package:
+        level: TRACE
+      my.other.package:
+        level: TRACE
+```
 
-at cluster level or at role level?
--> probably per role / role group
+**Settings per role** - All of these should be configurable per role and role group. Some sub-loggers are only available in certain roles.
 
 ```
 spec:
   someRole:
-    resources:
-      ...
-    logging:
-      stdout:
-        level: DEBUG
-        modules:
-          my.specific.package: TRACE
-          my.other.package: TRACE
-      file:
-        level: INFO
+    config:
+      logging:
+        ...
+    roleGroups:
+      default:
+        logging:
+          ...
+      aDifferentGroup:
+        logging:
+          ...
 ```
 
 
 === Deploying the Stack
 
-Our Oper
-
-== Decision Outcome - Summary
-
-We have already decided to use https://vector.dev/[Vector] as an aggregator. It looked good, no other options were evaluated.
-
-We chose to provide **plaintext logs on stdout** and **structured logs on file**. For the architecture, we chose to deploy the agent as a **sidecar** and **use an aggregator**. We chose to provide **OpenSearch** as a default Sink for logs.
+TODO
 
 == Consequences
 

--- a/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
+++ b/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
@@ -96,3 +96,40 @@ We chose to provide **plaintext logs on stdout** and **structured logs on file**
 
 * [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
 * … <!-- numbers of links can vary -->
+
+
+
+
+== Notes on CRD Fragment
+Configuration requirements
+
+* stdout and files should have different log levels
+* different packages/components should have different log levels
+
+
+at cluster level or at role level?
+-> probably per role / role group
+
+```
+spec:
+  someRole:
+    resources:
+      ...
+    logging:
+      stdout:
+        level: DEBUG
+        modules:
+          my.specific.package: TRACE
+          my.other.package: TRACE
+      file:
+        level: INFO
+```
+
+What should be the default level? WARN? INFO?
+
+
+
+
+
+
+what if we change log levels while the pod is running?

--- a/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
+++ b/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
@@ -1,4 +1,4 @@
-= [Logging and Log Aggregation Architecture]
+= Logging and Log Aggregation Architecture
 Felix Hennig <felix.hennig@stackable.tech>
 v0.1, 2022-10-26
 :status: [draft]
@@ -15,7 +15,7 @@ Technical Story: https://github.com/stackabletech/issues/issues/202, https://git
 
 Context: As of the day of writing, every product logs in its own log format to stdout. Logs cannot be viewed centrally, log levels cannot be set for individual parts of applications or across multiple products at once.
 
-// TODO: Are operator logs out of scope or in scope?
+Product logs cannot be correlated to operator logs easily, we want to have both aggregated in a central place (aggregating operator logs is in scope).
 
 == Decision Drivers
 
@@ -26,8 +26,6 @@ Context: As of the day of writing, every product logs in its own log format to s
 * **custom overrides** - The log format, aggregator and sink should be substitutable by the user.
 
 == Considered Options
-
-// TODO: Why vector?
 
 === Log Retrieval
 
@@ -42,7 +40,9 @@ Context: As of the day of writing, every product logs in its own log format to s
 
 == Decision Outcome
 
-We chose to provide **plaintext logs on stdout** and *structured logs on file**. For the architecture, we chose to deploy the agent as a **sidecar** and **use an aggregator**. We chose to provide **OpenSearch** as a default Sink for logs.
+We have already decided to use https://vector.dev/[Vector] as an aggregator. It looked good, no other options were evaluated.
+
+We chose to provide **plaintext logs on stdout** and **structured logs on file**. For the architecture, we chose to deploy the agent as a **sidecar** and **use an aggregator**. We chose to provide **OpenSearch** as a default Sink for logs.
 
 === Positive Consequences <!-- optional -->
 

--- a/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
+++ b/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
@@ -13,15 +13,17 @@ Technical Story: https://github.com/stackabletech/issues/issues/202, https://git
 
 // Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.
 
-Context: As of the day of writing, every product logs in its own log format to stdout. Logs cannot be viewed centrally, log levels cannot be set for individual parts of applications or across multiple products at once.
+As a user of the platform, I have poor visibility into what is happening in different components of the platform, as well as how components influence each other, especially the operator and the product clusters it manages.
 
-Product logs cannot be correlated to operator logs easily, we want to have both aggregated in a central place (aggregating operator logs is in scope).
+Logs usually give this insight. Currently, every pod logs to stdout with a certain default log format. For log configuration we support setting a custom log configuration file in some products.
+
+Logs are **not persisted**, a crashed pod is difficult to investigate. Logs are **not aggregated**, investigating issues that involve multiple pods is difficult. Log **configuration is difficult** or impossible.
 
 == Decision Drivers
 
 * **identical configuration** - All product logs should be configurable in the same way, no matter their underlying logging framework (log4j, logback, Python logging, etc.). Every product should have a logging section in its CRD.
 * **easily configured sinks** - A log sink (i.e. elasticsearch) should only be configured in a single place for the whole platform (not in every product instance).
-* **Support plaintext logs on stdout** - It is a Kubernetes convention to log in plaintext to stdout. This should be kept, as it is a useful tool for debugging.
+* **Support plaintext logs on stdout** - It is a Kubernetes convention to log in plaintext to stdout. This should be kept, as it is a useful tool for interactive debugging.
 * **custom overrides** - The log format, aggregator and sink should be substitutable by the user.
 * **transport security** - Logs should transmitted with encryption/TLS.
 
@@ -47,23 +49,13 @@ https://vector.dev/[Vector] has been picked without comparison to other existing
 
 === Log Retrieval Strategy
 
-
-
-* Parse logs as they are (in plaintext) vs. provide custom structured logs (i.e. json/XML)
-* Retrieve logs from stdout vs. from file
-
-* Logs on stdout are still useful, because you can read them with kubectl or k9s to debug things. In that case, they should be plain, so they are easy to read for a human.
-* Logs parsed by the aggregator are differt.
-  * Parsing plaintext logs can be tricky, because regexes are needed
-  * Using structured logs is much more robust.
-* Some products _need_ to log to file, because of _reasons_. They either cannot be configured differently (which ones?), have logs confidential logs that shouldn't go do stdout, or ...
-* File logs can be structured, as they are not meant to be read by a human.
+We want to parse logs out of structured log entries and also keep the stdout log as plaintext. Also, some products require reading log files instead of stdout. Which means **we opt to read logs from files for every product** and **parse structured log entries**.
 
 === Log Aggregation Architecture
 
-**Topology** - Vector offers multiple https://vector.dev/docs/setup/deployment/topologies/[topologies] and already lists pros and cons. An aggregator makes it easier to configure a sink: only one place to configure it (the aggregator has "multi-host context" as Vector calls it).
-
 **Agent role** - Vector offers multiple https://vector.dev/docs/setup/deployment/roles/#agent[roles] in which it can run. The DaemonSet is easier to deploy, and only one vector instance is running per host. But the sidecar has deeper integration with the product container and can read log files, something that we decided we need.
+
+**Topology** - Vector offers multiple https://vector.dev/docs/setup/deployment/topologies/[topologies] and already lists pros and cons. An aggregator makes it easier to configure a sink: only one place to configure it (the aggregator has "multi-host context" as Vector calls it). It also reduces requests made to the sink, as it aggregates and buffers requests.
 
 === Log Sink: OpenSearch
 
@@ -75,7 +67,7 @@ We want to make it easy for users to deploy OpenSearch, but also easy to switch 
 
 === Logging configuration
 
-**Log levels** - It is common to have four or five log levels: Error, Warning, Info, Debug and - optionally - Trace. We want to support them across all products.
+**Log levels** - It is common to have four or five log levels: Error, Warning, Info, Debug and - optionally - Trace. We want to support them across all products. The **default log level** should be Info.
 
 **stdout vs. file** - We want to have different log levels (and possibly other settings) for stdout and file output. This makes debugging easier, without also filling up the log aggregator with very chatty logs.
 
@@ -133,8 +125,6 @@ logging:
   enableVectorAgent: false  # defaults to true
 ```
 
-
-
 === Deploying the Stack
 
 The operator deploys the Vector agent as a sidecar and deploys the logging configuration for the product.
@@ -143,13 +133,17 @@ The aggregator and OpenSearch sink are deployed with Helm for now, with a plan t
 
 == Consequences
 
+
 === Positive
 
-* All logs can be accessed from a central placed, and logs for multiple products and operators can be correlated easily
+Logs across the platform (from products and operators) are **persisted** and **aggregated** in a central location. Crashed pods can be investigated, as well as issues involving multiple products.
 
 === Negative
 
-* Sidecar deployment has more overhead than the DaemonSet deployment
+* Every pod will contain a vector sidecar container, which adds overhead.
+* The unified logging configuration hides product specific logging settings.
+
+Changing a log level might lead to a pod getting restarted.
 
 
 == Links
@@ -157,8 +151,3 @@ The aggregator and OpenSearch sink are deployed with Helm for now, with a plan t
 * https://vector.dev/[Vector]
 * https://vector.dev/docs/setup/deployment/roles/[Vector Deployment Roles]
 * https://vector.dev/docs/setup/deployment/topologies/[Vector Deployment Topologies]
-
-== Open Questions
-
-* What should be the default level? WARN? INFO?
-* What if we change log levels while the pod is running?

--- a/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
+++ b/modules/contributor/pages/adr/ADRXYZ_logging_architecture.adoc
@@ -1,0 +1,77 @@
+= [Logging and Log Aggregation Architecture]
+Felix Hennig <felix.hennig@stackable.tech>
+v0.1, 2022-10-26
+:status: [draft]
+
+* Status: {status}
+* Deciders: Stackable Team
+* Date: 2022-10-26
+
+Technical Story: https://github.com/stackabletech/issues/issues/202, https://github.com/stackabletech/issues/issues/261
+
+== Context and Problem Statement
+
+// [Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+How can we aggregate logs from all products?
+
+== Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+== Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* … <!-- numbers of options can vary -->
+
+== Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+=== Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+=== Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+== Pros and Cons of the Options <!-- optional -->
+
+=== [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+=== [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+=== [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+== Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->


### PR DESCRIPTION
fixes #279 in main

I've tried the regular anchor syntax for antora, but it didn't work. I suspect, because we made the heading with html instead of adoc. So I made the anchor also in html.

I've tested it, and search for hive will no jump to the right place.