### PR TITLE
Fixes names of the Helm repos to be consistent with the rest of the documentation

### DIFF
--- a/modules/ROOT/pages/release_notes.adoc
+++ b/modules/ROOT/pages/release_notes.adoc
@@ -168,22 +168,22 @@ To install the release 22.11 run
 
 [source,console]
 ----
-$ helm repo add stackable https://repo.stackable.tech/repository/helm-stable/
-$ helm repo update stackable
-$ helm install --wait airflow-operator stackable/airflow-operator --version 0.6.0
-$ helm install --wait commons-operator stackable/commons-operator --version 0.4.0
-$ helm install --wait druid-operator stackable/druid-operator --version 0.8.0
-$ helm install --wait hbase-operator stackable/hbase-operator --version 0.5.0
-$ helm install --wait hdfs-operator stackable/hdfs-operator --version 0.6.0
-$ helm install --wait hive-operator stackable/hive-operator --version 0.8.0
-$ helm install --wait kafka-operator stackable/kafka-operator --version 0.8.0
-$ helm install --wait nifi-operator stackable/nifi-operator --version 0.8.0
-$ helm install --wait opa-operator stackable/opa-operator --version 0.11.0
-$ helm install --wait secret-operator stackable/secret-operator --version 0.6.0
-$ helm install --wait spark-k8s-operator stackable/spark-k8s-operator --version 0.6.0
-$ helm install --wait superset-operator stackable/superset-operator --version 0.7.0
-$ helm install --wait trino-operator stackable/trino-operator --version 0.7.0
-$ helm install --wait zookeeper-operator stackable/zookeeper-operator --version 0.12.0
+$ helm repo add stackable-stable https://repo.stackable.tech/repository/helm-stable/
+$ helm repo update stackable-stable
+$ helm install --wait airflow-operator stackable-stable/airflow-operator --version 0.6.0
+$ helm install --wait commons-operator stackable-stable/commons-operator --version 0.4.0
+$ helm install --wait druid-operator stackable-stable/druid-operator --version 0.8.0
+$ helm install --wait hbase-operator stackable-stable/hbase-operator --version 0.5.0
+$ helm install --wait hdfs-operator stackable-stable/hdfs-operator --version 0.6.0
+$ helm install --wait hive-operator stackable-stable/hive-operator --version 0.8.0
+$ helm install --wait kafka-operator stackable-stable/kafka-operator --version 0.8.0
+$ helm install --wait nifi-operator stackable-stable/nifi-operator --version 0.8.0
+$ helm install --wait opa-operator stackable-stable/opa-operator --version 0.11.0
+$ helm install --wait secret-operator stackable-stable/secret-operator --version 0.6.0
+$ helm install --wait spark-k8s-operator stackable-stable/spark-k8s-operator --version 0.6.0
+$ helm install --wait superset-operator stackable-stable/superset-operator --version 0.7.0
+$ helm install --wait trino-operator stackable-stable/trino-operator --version 0.7.0
+$ helm install --wait zookeeper-operator stackable-stable/zookeeper-operator --version 0.12.0
 ----
 
 ==== Breaking changes
@@ -387,22 +387,22 @@ To install the release 22.09 run
 
 [source,console]
 ----
-$ helm repo add stackable https://repo.stackable.tech/repository/helm-stable/
-$ helm repo update stackable
-$ helm install --wait airflow-operator stackable/airflow-operator --version 0.5.0
-$ helm install --wait commons-operator stackable/commons-operator --version 0.3.0
-$ helm install --wait druid-operator stackable/druid-operator --version 0.7.0
-$ helm install --wait hbase-operator stackable/hbase-operator --version 0.4.0
-$ helm install --wait hdfs-operator stackable/hdfs-operator --version 0.5.0
-$ helm install --wait hive-operator stackable/hive-operator --version 0.7.0
-$ helm install --wait kafka-operator stackable/kafka-operator --version 0.7.0
-$ helm install --wait nifi-operator stackable/nifi-operator --version 0.7.0
-$ helm install --wait opa-operator stackable/opa-operator --version 0.10.0
-$ helm install --wait secret-operator stackable/secret-operator --version 0.5.0
-$ helm install --wait spark-k8s-operator stackable/spark-k8s-operator --version 0.5.0
-$ helm install --wait superset-operator stackable/superset-operator --version 0.6.0
-$ helm install --wait trino-operator stackable/trino-operator --version 0.6.0
-$ helm install --wait zookeeper-operator stackable/zookeeper-operator --version 0.11.0
+$ helm repo add stackable-stable https://repo.stackable.tech/repository/helm-stable/
+$ helm repo update stackable-stable
+$ helm install --wait airflow-operator stackable-stable/airflow-operator --version 0.5.0
+$ helm install --wait commons-operator stackable-stable/commons-operator --version 0.3.0
+$ helm install --wait druid-operator stackable-stable/druid-operator --version 0.7.0
+$ helm install --wait hbase-operator stackable-stable/hbase-operator --version 0.4.0
+$ helm install --wait hdfs-operator stackable-stable/hdfs-operator --version 0.5.0
+$ helm install --wait hive-operator stackable-stable/hive-operator --version 0.7.0
+$ helm install --wait kafka-operator stackable-stable/kafka-operator --version 0.7.0
+$ helm install --wait nifi-operator stackable-stable/nifi-operator --version 0.7.0
+$ helm install --wait opa-operator stackable-stable/opa-operator --version 0.10.0
+$ helm install --wait secret-operator stackable-stable/secret-operator --version 0.5.0
+$ helm install --wait spark-k8s-operator stackable-stable/spark-k8s-operator --version 0.5.0
+$ helm install --wait superset-operator stackable-stable/superset-operator --version 0.6.0
+$ helm install --wait trino-operator stackable-stable/trino-operator --version 0.6.0
+$ helm install --wait zookeeper-operator stackable-stable/zookeeper-operator --version 0.11.0
 ----
 
 ==== Breaking changes


### PR DESCRIPTION
/fixes #246 

These are all the references I could find for the wrong repo name (`stackable`) in this repository.
The "Getting Started" guides are now autogenerated it seems so it shouldn't happen there anymore.