### PR TITLE
Added the noindex removal step to the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ ANTORAFLAGS :=
 build:
 	node_modules/.bin/gulp --cwd ui bundle
 	node_modules/.bin/antora generate $(PLAYBOOK) $(ANTORAFLAGS)
+	scripts/fix_noindex.sh
 
 .PHONY: clean
 clean:

--- a/scripts/fix_noindex.sh
+++ b/scripts/fix_noindex.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# This script removes the 'noindex' meta tag from the main entrypoint into the docs.
+# The index.html is a 301 redirect to the /home/stable/index.html path, where the landing page is.
+# 
+# We have problems with Google not indexing the docs, and we hope that this might fix these
+# problems. 
+#
+# The github issue: https://github.com/stackabletech/documentation/issues/324
 
 index_file="$(dirname "$0")/../build/site/index.html"
 

--- a/scripts/fix_noindex.sh
+++ b/scripts/fix_noindex.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+
+index_file="$(dirname "$0")/../build/site/index.html"
+
+sed -i '/noindex/d' $index_file


### PR DESCRIPTION
fixes #324 

An attempt to remove the noindex meta tag from the redirect to hopefully get our docs indexed by google