### PR TITLE
 Rename clusterOperation flag "reconcilePaused" to "reconciliationPaused"

### DIFF
--- a/modules/concepts/examples/cluster-operations.yaml
+++ b/modules/concepts/examples/cluster-operations.yaml
@@ -5,5 +5,5 @@ metadata:
   name: my-cluster
 spec:
   clusterOperation:
-    reconcilePaused: false # <1>
+    reconciliationPaused: false # <1>
     stopped: false # <2>

--- a/modules/concepts/pages/operations/cluster_operations.adoc
+++ b/modules/concepts/pages/operations/cluster_operations.adoc
@@ -3,7 +3,7 @@
 
 Stackable operators offer different cluster operations to control the reconciliation process. This is useful when updating operators, debugging or testing of new settings:
 
-* `reconcilePaused` - Stop the operator from reconciling the cluster spec. The status will still be updated.
+* `reconciliationPaused` - Stop the operator from reconciling the cluster spec. The status will still be updated.
 * `stopped` - Stop all running pods but keep updating all deployed resources like `ConfigMaps`, `Services` and the cluster status.
 
 == Example
@@ -12,11 +12,11 @@ Stackable operators offer different cluster operations to control the reconcilia
 ----
 include::example$cluster-operations.yaml[]
 ----
-<1> The `clusterOperation.reconcilePaused` flag set to `true` stops the operator from reconciling any changes to the cluster spec. The cluster status is still updated.
+<1> The `clusterOperation.reconciliationPaused` flag set to `true` stops the operator from reconciling any changes to the cluster spec. The cluster status is still updated.
 <2> The `clusterOperation.stopped` flag set to `true` stops all pods in the cluster. This is done by setting all deployed `StatefulSet` replicas to 0.
 
 == Notes
 
-If not specified, `clusterOperation.reconcilePaused` and `clusterOperation.stopped` default to `false`.
+If not specified, `clusterOperation.reconciliationPaused` and `clusterOperation.stopped` default to `false`.
 
-IMPORTANT: When setting `clusterOperation.reconcilePaused` and `clusterOperation.stopped` to true in the same step, `clusterOperation.reconcilePaused` will take precedence. This means the cluster will stop reconciling immediately and the `stopped` field is ignored. To avoid this, the cluster should first be stopped and then paused.
+IMPORTANT: When setting `clusterOperation.reconciliationPaused` and `clusterOperation.stopped` to true in the same step, `clusterOperation.reconciliationPaused` will take precedence. This means the cluster will stop reconciling immediately and the `stopped` field is ignored. To avoid this, the cluster should first be stopped and then paused.


### PR DESCRIPTION
 Rename clusterOperation flag "reconcilePaused" to "reconciliationPaused"
 
 This change should be backported to 23.7 and 23.4.