### PR TITLE
Add redirect from versioned link to stable

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -7,13 +7,19 @@ site:
   keys:
     enable_tracking: true
 
+# URL config settings.
+# docs: https://docs.antora.org/antora/latest/playbook/configure-urls/
 urls:
-  # The symbolic name of the latest stable version. This is used to generate redirects to the latest version.
+  # The symbolic name of the latest stable version, and how to redirect from/to it.
+  # with 'redirect:to', the _actual_ version link is a redirect, and the _actual_ link 
+  # contains the symbolic name, i.e. stable.
+  # As the user browses the latest docs, there will be 'stable' in the links. Also 
+  # search engines will see the 'stable' link and index those pages, so if we release
+  # a new version, these links will be already in the index, which is good.
+  # Linking to the latest version by version number is still possible, and after the
+  # latest version is not latest anymore, the redirect is instead the actual URL.
   latest_version_segment: stable
-  # This configures stable version links to be redirects, i.e.
-  # /commons-operator/stable/index.html redirects to /commons-operator/23.11/index.html
-  # if 23.11 is the latest version.
-  latest_version_segment_strategy: redirect:from
+  latest_version_segment_strategy: redirect:to
   # We deploy our site on netlify, so we use their redirect config mechanism
   redirect_facility: netlify
 

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -8,9 +8,13 @@ site:
     enable_tracking: true
 
 urls:
-  # This replaces the component version in the URL of the latest stable version with 'stable'
-  # i.e. /commons-operator/stable/index.html instead of /commons-operator/0.3/index.html
+  # The symbolic name of the latest stable version. This is used to generate redirects to the latest version.
   latest_version_segment: stable
+  # This configures stable version links to be redirects, i.e.
+  # /commons-operator/stable/index.html redirects to /commons-operator/23.11/index.html
+  # if 23.11 is the latest version.
+  latest_version_segment_strategy: redirect:from
+  # We deploy our site on netlify, so we use their redirect config mechanism
   redirect_facility: netlify
 
 content:


### PR DESCRIPTION
Currently there is no way to link to the latest version by its actual version number, which is annoying. There is only the 'stable' link (i.e. https://docs.stackable.tech/home/stable/concepts/product_image_selection). Previous versions are linkable by their version number (i.e. https://docs.stackable.tech/home/23.4/concepts/product_image_selection). 

This PR adds a redirect from the actual version to 'stable'.

**Why redirect from the number to stable, and not the other way round?** Where do URLs actually end up? Users might send each other links, they are just used in the moment and then the URL doesn't really matter. For bookmarking a URL, sometimes bookmarking a link that always points to the latest docs might be better, sometimes you might want a stable link. Both are possible, just the default would be to link 'stable'. **The main reason is SEO** - Google will index the 'stable' links, and when we release a new version, the pages will update, instead of google having to find the new version number. If a new version is released, google will find the now latest-1 version on a new indexing run and will index it too, but it will also update the 'stable' pages.