### PR TITLE
Add a section on Export Controls

### DIFF
--- a/modules/ROOT/nav2.adoc
+++ b/modules/ROOT/nav2.adoc
@@ -4,3 +4,4 @@
 * xref:product-information.adoc[]
 * xref:policies.adoc[]
 * xref:licenses.adoc[Licenses]
+* xref:export.adoc[Export Control]

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -6,7 +6,7 @@ The USA adopts the https://en.wikipedia.org/wiki/Export_Administration_Regulatio
 
 All of our products are outside of the scope of EAR because they fall under the _publicly available_ exemption and do not contain non-standard cryptography.
 
-NOTE: That means E-Mail notifications to the NSA and BIS are not required and therefore not published here.
+NOTE: That means E-Mail notifications to the NSA and BIS are not required and are therefore not published here.
 
 In particular:
 

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -9,7 +9,7 @@ That means E-Mail notifications to the NSA and BIS are not required and therefor
 
 In particular:
 
-* We are exempt under https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.3[EAR 734.3(b)] because we are published according to EAR 734.7
+* We are exempt under https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.3[EAR 734.3(b)] because we are published according to https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7[EAR 734.7]
 * We are exempt under https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7[EAR 742.15(b)] as all our software only includes https://ecfr.io/Title-15/Section-772.1[standard encryption]
 
 The Stackable Data Platform is open source, and the source code of all the components can be found on https://github.com/stackabletech/[GitHub].

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -1,0 +1,15 @@
+= Export Control
+
+== USA
+
+The USA have the https://en.wikipedia.org/wiki/Export_Administration_Regulations[Export Administration Regulations (EAR)] as the primary regulation to control export.
+
+All of our products are exempt from the EAR regulations because they are publicly available and do not contain non-standard cryptography.
+That means E-Mail notifications to the NSA and BIS are not required and therefore not published here.
+
+In particular:
+
+* We are exempt under https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.3[EAR 734.3(b)] because we are published according to EAR 734.7
+* We are exempt under https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7[EAR 742.15(b)] as all our software only includes https://ecfr.io/Title-15/Section-772.1[standard encryption]
+
+The Stackable Data Platform is open source, and the source code of all the components can be found on https://github.com/stackabletech/[GitHub].

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -10,7 +10,7 @@ NOTE: That means E-Mail notifications to the NSA and BIS are not required and th
 
 In particular:
 
-* We are exempt under https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.3[EAR 734.3(b)] because we are published according to https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7[EAR 734.7]
+* We are exempt under https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.3[EAR 734.3(b)] because we publish according to https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7[EAR 734.7]
 * We are exempt under https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7[EAR 742.15(b)] as all our software only includes https://ecfr.io/Title-15/Section-772.1[standard encryption]
 
 The Stackable Data Platform is open source, and the source code of all the components can be found on https://github.com/stackabletech/[GitHub].

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -4,8 +4,9 @@
 
 The USA have the https://en.wikipedia.org/wiki/Export_Administration_Regulations[Export Administration Regulations (EAR)] as the primary regulation to control export.
 
-All of our products are exempt from the EAR regulations because they are publicly available and do not contain non-standard cryptography.
-That means E-Mail notifications to the NSA and BIS are not required and therefore not published here.
+All of our products are outside of the scope of EAR because they fall under the _publicly available_ exemption and do not contain non-standard cryptography.
+
+NOTE: That means E-Mail notifications to the NSA and BIS are not required and therefore not published here.
 
 In particular:
 

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -11,6 +11,6 @@ NOTE: That means E-Mail notifications to the NSA and BIS are not required and ar
 In particular:
 
 * We are exempt under https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.3[EAR 734.3(b)] because we publish according to https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7[EAR 734.7]
-* We are exempt under https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7[EAR 742.15(b)] as all our software only includes https://ecfr.io/Title-15/Section-772.1[standard encryption]
+* We are exempt under https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-742/section-742.15[EAR 742.15(b)] as our software includes only https://ecfr.io/Title-15/Section-772.1[standard encryption]
 
 The Stackable Data Platform is open source, and the source code of all the components can be found on https://github.com/stackabletech/[GitHub].

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -2,7 +2,7 @@
 
 == USA
 
-The USA have the https://en.wikipedia.org/wiki/Export_Administration_Regulations[Export Administration Regulations (EAR)] as the primary regulation to control export.
+The USA adopts the https://en.wikipedia.org/wiki/Export_Administration_Regulations[Export Administration Regulations (EAR)] as the primary regulation to control exports.
 
 All of our products are outside of the scope of EAR because they fall under the _publicly available_ exemption and do not contain non-standard cryptography.
 

--- a/supplemental-ui/partials/navbar.hbs
+++ b/supplemental-ui/partials/navbar.hbs
@@ -47,9 +47,10 @@
 <div class="navbar-sub-item drop-down">
     Policies and Licenses
     <div class="drop-down-content">
-        <a class="drop-down-item" href="{{{ relativize "/home/stable/product-information.html" }}}">Product Information</a>
+        <a class="drop-down-item" href="{{{ relativize "/home/stable/product-information" }}}">Product Information</a>
         <a class="drop-down-item" href="{{{ relativize (versioned "home" page "policies.html") }}}">Policies</a>
-        <a class="drop-down-item" href="{{{ relativize "/home/stable/licenses.html" }}}">Licenses</a>
+        <a class="drop-down-item" href="{{{ relativize "/home/stable/licenses" }}}">Licenses</a>
+        <a class="drop-down-item" href="{{{ relativize "/home/stable/export" }}}">Licenses</a>
     </div>
 </div>
 <a class="navbar-sub-item" href="{{{ relativize (versioned "home" page "contributor/index.html") }}}">Contribute</a>

--- a/supplemental-ui/partials/navbar.hbs
+++ b/supplemental-ui/partials/navbar.hbs
@@ -50,7 +50,7 @@
         <a class="drop-down-item" href="{{{ relativize "/home/stable/product-information" }}}">Product Information</a>
         <a class="drop-down-item" href="{{{ relativize (versioned "home" page "policies.html") }}}">Policies</a>
         <a class="drop-down-item" href="{{{ relativize "/home/stable/licenses" }}}">Licenses</a>
-        <a class="drop-down-item" href="{{{ relativize "/home/stable/export" }}}">Licenses</a>
+        <a class="drop-down-item" href="{{{ relativize "/home/stable/export" }}}">Export Control</a>
     </div>
 </div>
 <a class="navbar-sub-item" href="{{{ relativize (versioned "home" page "contributor/index.html") }}}">Contribute</a>


### PR DESCRIPTION
The rendered page can be found here: https://deploy-preview-545--stackable-docs.netlify.app/home/nightly/export

@fhennig The link in the navbar is now dead for 23.11 and previous releases, do we need to back port it somehow or what would you suggest?