### PR TITLE
Adding warning and hint for listener operator

### DIFF
--- a/modules/concepts/pages/arm64-support.adoc
+++ b/modules/concepts/pages/arm64-support.adoc
@@ -25,6 +25,8 @@ According to our https://docs.stackable.tech/home/stable/airflow/getting_started
 helm install commons-operator stackable-stable/commons-operator --namespace stackable-operators --create-namespace --version=23.11.0 --set image.repository=docker.stackable.tech/stackable-experimental/commons-operator
 ----
 
+WARNING: Listener operator 23.11.0 not available for bare metal arm64 machines
+
 By declaring `--set image.repository=docker.stackable.tech/stackable-experimental/commons-operator` you will overwrite the image selected by default with one located in the organization `stackable-experimental`. The other operators can be installed in the same way.
 
 WARNING: You have to install every operator you need for a given demo individually with helm using `--skip-release` with stackablectl. Otherwise, it will try to install x86 operators and pull ARM64 product images afterwards.
@@ -61,7 +63,7 @@ git clone git@github.com:stackabletech/demos.git
 cd demos && git pull && git checkout spike/demos-on-arm
 ----
 ==== 3. Install stackable operators ( release 23.11.0 )
-NOTE: This executes a script where all operators with version 23.11.0 are installed. You can omit this step and only install operators you want by copying the corresponding `helm` command.
+NOTE: This executes a script where all operators (except listener operator) with version 23.11.0 are installed. You can omit this step and only install operators you want by copying the corresponding `helm` command.
 
 [source,bash]
 ----


### PR DESCRIPTION
Added warning for listener operator not working in 23.11.0

I've installed the ./arm.sh script on Azure and got an image pull backoff. Research showed that the pods

`k8s_external-provisioner_listener-operator-controller-deployment` and `k8s_node-driver-registrar_listener-operator-node-daemonset` are still `amd64`.