### PR TITLE
Update product image selection page

### DIFF
--- a/modules/concepts/pages/product-image-selection.adoc
+++ b/modules/concepts/pages/product-image-selection.adoc
@@ -21,7 +21,7 @@ starting from the simple way of using the default images to explaining how to us
 
 == Product and Stackable version explained
 
-All products of the Stackable Data Platform run on Kubernetes and are managed by Stackable Operators and one operator is responsible for exactly one product like Apache Spark.
+All products of the Stackable Data Platform run on Kubernetes and are managed by Stackable Operators. One operator is responsible for exactly one product, for example Apache Spark, but can manage multiple instances (with different versions) of the product at the same time.
 The operators read the Stacklet definition and deploy appropriate StatefulSets which lead to the creation of Pods, which in the end require _container images_ to run.
 These images contain different tools for initialization jobs and/or the actual product itself and the images are version and architecture specific.
 

--- a/modules/concepts/pages/product-image-selection.adoc
+++ b/modules/concepts/pages/product-image-selection.adoc
@@ -89,7 +89,7 @@ spec:
 
 NOTE: If the Kubernetes cluster does not have internet access, a xref:_custom_docker_registry[] or xref:_custom_images[] can be used.
 
-You only need to specify the product version but _can_ also specify an exiplicit Stackable version.
+You only need to specify the product version but _can_ also specify an explicit Stackable version.
 the product version can be found on the xref:operators:supported_versions.adoc[list of supported product versions] or on the product operator documentation page.
 The requirement to specify a product version might be relaxed in the future, as every platform release might ship with a recommended product version, which might be used by default.
 

--- a/modules/concepts/pages/product-image-selection.adoc
+++ b/modules/concepts/pages/product-image-selection.adoc
@@ -14,7 +14,7 @@ spec:
     # stackableVersion: 24.3.0 optional <.>
 ----
 <.> The version of your product - consult the product operator documentation to find out about supported product versions.
-<.> The version of the Stackable Data Platform - simply omit this to use the operator version.
+<.> The version of the Stackable Data Platform. If you omit it, the operator will use it's own version together with the product version to select the product image.
 
 This page explains the different ways of specifying product images and the components that are involved,
 starting from the simple way of using the default images to explaining how to use custom or mirrored registries as well as custom images.

--- a/modules/concepts/pages/product-image-selection.adoc
+++ b/modules/concepts/pages/product-image-selection.adoc
@@ -133,7 +133,7 @@ spec:
     productVersion: 3.3.1
 ----
 
-Even though the product version is not used anymore for image selection, you still need to provide it, as the Stackable Operators configure their respective products based on the product version.
+Even though the product version is not used anymore for image selection, you still need to provide it, as the operators configure their respective products based on the product version.
 This affects e.g. configuration properties or available product features.
 Only when the correct product version is given to the operator, the product will work correctly, so you need to provide the product version that you have used in your custom image.
 

--- a/modules/concepts/pages/product-image-selection.adoc
+++ b/modules/concepts/pages/product-image-selection.adoc
@@ -1,20 +1,35 @@
 = Product image selection
 :page-aliases: product_image_selection.adoc
 :description: This page describes the different ways of specifying a product image to use in your product deployment.
-:keywords: Kubernetes, operator, docker, image, tags
+:keywords: Kubernetes, operator, docker, registry, custom image, tags
 
-All products of the Stackable Data Platform run on Kubernetes and are managed by Stackable Operators.
-One operator is responsible for exactly one product like Apache Spark.
-The products are deployed using `Pods` and their `Containers` to initialize and run the respective product.
-Containers require images (e.g. Docker) to run of.
-These images contain different tools for initialization jobs and/or the actual product itself.
-Images are prepared for different architectures and different product versions.
+To run any product on the Stackable Data Platform, you need to specify which version you want to run in the resource definition (i.e. a SparkApplication or DruidCluster).
+The simplest way to do this is this:
+
+[source,yaml]
+----
+spec:
+  image:
+    productVersion: 1.2.3 <.>
+    # stackableVersion: 24.3.0 optional <.>
+----
+<.> The version of your product - consult the product operator documentation to find out about supported product versions.
+<.> The version of the Stackable Data Platform - simply omit this to use the operator version.
+
+This page explains the different ways of specifying product images and the components that are involved,
+starting from the simple way of using the default images to explaining how to use custom or mirrored registries as well as custom images.
+
+== Product and Stackable version explained
+
+All products of the Stackable Data Platform run on Kubernetes and are managed by Stackable Operators and one operator is responsible for exactly one product like Apache Spark.
+The operators read the Stacklet definition and deploy appropriate StatefulSets which lead to the creation of Pods, which in the end require _container images_ to run.
+These images contain different tools for initialization jobs and/or the actual product itself and the images are version and architecture specific.
 
 Stackable uses two separate versions to describe the images that are provided as part of the platform:
 
 
 **Product version** +
-This is the version of the product which this image provides, so this could for example be Kafka 3.3.1
+This is the version of the product which this image provides, so this could for example be Kafka 3.3.1.
 
 TIP: You can find all products and their supported versions in the xref:operators:supported_versions.adoc[supported versions overview].
 You can also find the supported versions per product on each operator page, for example for xref:kafka:index.adoc#_supported_versions[Apache Kafka].
@@ -60,28 +75,32 @@ At the bottom of this page in the <<_common_scenarios, common scenarios>> sectio
 
 == Stackable provided images
 
-If your Kubernetes cluster has internet access, the easiest way is to use the publicly available images from the https://docker.stackable.tech/[Image registry hosted by Stackable].
-If the Kubernetes cluster does not have internet access, a xref:_custom_docker_registry[] or xref:_custom_images[] can be used.
-
-Currently, you need to specify the product version. This can be found on the xref:operators:supported_versions.adoc[list of supported product versions] or on the website of the product itself.
-This requirement might be relaxed in the future, as every platform release will ship wth a recommended product versions, which will be used by default.
-
-Additionally, as images should be updated from time to time (e.g. new base image, security updates), a Stackable version can be provided. An image with the Stackable version `23.7.0` is fixed and will never change. Security updates within a release line will result in patch version bumps in the Stackable version to e.g. `23.7.1`.
-
-If you don't specify the Stackable version, the operator will use its own version, e.g. `23.7.0`.
-When using a nightly operator or a `pr` version, it will use the nightly `0.0.0-dev` image.
-
-All the available images (with their product and stackable version) can be found in our https://repo.stackable.tech/#browse/browse:docker:v2%2Fstackable[docker repository].
-
-The versions need to be specified as follows:
+If your Kubernetes cluster has internet access, the easiest way is to use the publicly available images from the https://docker.stackable.tech/[Image registry hosted by Stackable] (as has been noted at the beginning of the page):
 
 [source,yaml]
 ----
 spec:
   image:
-    productVersion: 3.3.1
-    # stackableVersion: 23.7.0 # optional
+    productVersion: 3.3.1 <.>
+    # stackableVersion: 23.7.0 # optional <.>
 ----
+<.> The version of your product - consult the product operator documentation to find out about supported product versions.
+<.> The version of the Stackable Data Platform - simply omit this to use the operator version.
+
+NOTE: If the Kubernetes cluster does not have internet access, a xref:_custom_docker_registry[] or xref:_custom_images[] can be used.
+
+You only need to specify the product version but _can_ also specify an exiplicit Stackable version.
+the product version can be found on the xref:operators:supported_versions.adoc[list of supported product versions] or on the product operator documentation page.
+The requirement to specify a product version might be relaxed in the future, as every platform release might ship with a recommended product version, which might be used by default.
+
+As images should be updated from time to time (e.g. new base image, security updates), a Stackable version can be provided.
+An image with the Stackable version `23.7.0` is fixed and will never change.
+Security updates within a release line will result in patch version bumps in the Stackable version to e.g. `23.7.1`.
+
+If you don't specify the Stackable version, the operator will use its own version, e.g. `23.7.0`.
+When using a nightly operator or a `pr` version, it will use the nightly `0.0.0-dev` image.
+
+All the available images (with their product and stackable version) can be found in our https://repo.stackable.tech/#browse/browse:docker:v2%2Fstackable[docker repository].
 
 == Custom docker registry
 
@@ -115,15 +134,14 @@ spec:
     productVersion: 3.3.1
 ----
 
-The Stackable Operators configure their respective products based on the product version.
-This affects e.g. configuration properties or available features.
-Therefore, the operators are dependent on the product and its product version contained in the custom image.
-It's your responsibility to put in the correct product version.
+Even though the product version is not used anymore for image selection, you still need to provide it, as the Stackable Operators configure their respective products based on the product version.
+This affects e.g. configuration properties or available product features.
+Only when the correct product version is given to the operator, the product will work correctly, so you need to provide the product version that you have used in your custom image.
 
-Using custom images has a few limitations that users should be aware of.
+Using custom images has a few limitations that users should be aware of:
 
 * The images will *have* to have the same structures that Stackable operators expect.
-This should usually be ensured by specifying a Stackable image in the `FROM` clause of the Dockerfile.
+This should usually be ensured by specifying a Stackable image in the `FROM` clause of the Dockerfile (all the available images can be found in our https://repo.stackable.tech/#browse/browse:docker:v2%2Fstackable[docker repository] - the schema is typically: `docker.stackable.tech/stackable/<product>:<product-version>-stackable<stackable-version>`).
 
 * Images will have to be upgraded for every new Stackable release to follow structural changes that Stackable may have made to their images.
 When deriving images from official Stackable images this will mean updating the version of the image in the `FROM` clause to the correct Stackable release.
@@ -131,10 +149,10 @@ When deriving images from official Stackable images this will mean updating the 
 * It is not possible to update the Stackable Platform to a new version without changing the deployed cluster definitions when using custom images.
 The recommended process here is:
 
-** Tag clusters as "do not reconcile" (see xref:operations/cluster_operations.adoc[])
+** Set `reconciliationPaused` to `true` in your product cluster (see xref:operations/cluster_operations.adoc[])
 ** Update Stackable platform
 ** Change custom images in cluster specifications
-** Remove "do not reconcile flag"
+** Set `reconciliationPaused` to `false` again to start reconciliation again
 
 ## [[common_scenarios]] Common Scenarios
 

--- a/modules/concepts/pages/product-image-selection.adoc
+++ b/modules/concepts/pages/product-image-selection.adoc
@@ -91,7 +91,6 @@ NOTE: If the Kubernetes cluster does not have internet access, a xref:_custom_do
 
 You only need to specify the product version but _can_ also specify an explicit Stackable version.
 the product version can be found on the xref:operators:supported_versions.adoc[list of supported product versions] or on the product operator documentation page.
-The requirement to specify a product version might be relaxed in the future, as every platform release might ship with a recommended product version, which might be used by default.
 
 As images should be updated from time to time (e.g. new base image, security updates), a Stackable version can be provided.
 An image with the Stackable version `23.7.0` is fixed and will never change.

--- a/modules/concepts/pages/product-image-selection.adoc
+++ b/modules/concepts/pages/product-image-selection.adoc
@@ -22,7 +22,7 @@ starting from the simple way of using the default images to explaining how to us
 == Product and Stackable version explained
 
 All products of the Stackable Data Platform run on Kubernetes and are managed by Stackable Operators. One operator is responsible for exactly one product, for example Apache Spark, but can manage multiple instances (with different versions) of the product at the same time.
-The operators read the Stacklet definition and deploy appropriate StatefulSets which lead to the creation of Pods, which in the end require _container images_ to run.
+The operators transform a Stacklet definition (for example a SparkApplication object) into Kubernetes native objects. Some of these objects are Pods and they  require _container images_ to run.
 These images contain different tools for initialization jobs and/or the actual product itself and the images are version and architecture specific.
 
 Stackable uses two separate versions to describe the images that are provided as part of the platform:


### PR DESCRIPTION
- give a simple "TLDR" style config snippet right in the beginning
- fix some typos and wordings
- explicitly state where to find base images for custom images