### PR TITLE
feat: Add the Atlas extension to allow for partial builds

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -188,7 +188,11 @@ ui:
   supplemental_files: ./supplemental-ui
 antora:
   extensions:
+    # The lunr extension is used for search
     - '@antora/lunr-extension'
+    # The Atlas extension is used to generate a site manifest to allow for partial builds
+    # https://gitlab.com/antora/antora-atlas-extension
+    - '@antora/atlas-extension'
 asciidoc:
   attributes:
     base-repo: https://github.com/stackabletech

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -177,7 +177,11 @@ ui:
   supplemental_files: ./supplemental-ui
 antora:
   extensions:
+    # The lunr extension is used for search
     - '@antora/lunr-extension'
+    # The Atlas extension is used to generate a site manifest to allow for partial builds
+    # https://gitlab.com/antora/antora-atlas-extension
+    - '@antora/atlas-extension'
 asciidoc:
   attributes:
     base-repo: https://github.com/stackabletech

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "ui"
       ],
       "dependencies": {
+        "@antora/atlas-extension": "^1.0.0-alpha.2",
         "@antora/lunr-extension": "^1.0.0-alpha.8"
       },
       "devDependencies": {
@@ -36,6 +37,20 @@
         "@antora/logger": "3.1.7",
         "@antora/user-require-helper": "~2.0",
         "@asciidoctor/core": "~2.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@antora/atlas-extension": {
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@antora/atlas-extension/-/atlas-extension-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-tOQy3eQjvoYGV3UnDaOjkaCehbWSpjQWRdCCYXx8c2Do4rysclOVVN4t4AsfeOHK+BoWlKqa7mldb1DCYOBQTw==",
+      "dependencies": {
+        "@antora/expand-path-helper": "~2.0",
+        "cache-directory": "~2.0",
+        "node-gzip": "~1.1",
+        "simple-get": "~4.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -114,7 +129,6 @@
     },
     "node_modules/@antora/expand-path-helper": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MPL-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -2721,7 +2735,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cache-directory/-/cache-directory-2.0.0.tgz",
       "integrity": "sha512-7YKEapH+2Uikde8hySyfobXBqPKULDyHNl/lhKm7cKf/GJFdG/tU/WpLrOg2y9aUrQrWUilYqawFIiGJPS6gDA==",
-      "dev": true,
       "dependencies": {
         "xdg-basedir": "^3.0.0"
       },
@@ -4235,7 +4248,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -9985,7 +9997,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -10317,6 +10328,11 @@
       "version": "1.0.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-gzip": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/node-gzip/-/node-gzip-1.1.2.tgz",
+      "integrity": "sha512-ZB6zWpfZHGtxZnPMrJSKHVPrRjURoUzaDbLFj3VO70mpLTW5np96vXyHwft4Id0o+PYIzgDkBUjIzaNHhQ8srw=="
     },
     "node_modules/node-releases": {
       "version": "2.0.9",
@@ -10709,7 +10725,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -14649,7 +14664,6 @@
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14670,7 +14684,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -17986,7 +17999,6 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write": {
@@ -18026,7 +18038,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha512-1Dly4xqlulvPD3fZUQJLY+FUIeqN3N2MM3uqe4rCJftAvOjFa3jFGfctOgluGx4ahPbUCsZkmJILiP0Vi4T6lQ==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@antora/site-generator": "^3.1.7"
   },
   "dependencies": {
+    "@antora/atlas-extension": "^1.0.0-alpha.2",
     "@antora/lunr-extension": "^1.0.0-alpha.8"
   },
   "workspaces": [


### PR DESCRIPTION
The extension generates a `https://docs.example.org/site-manifest.json` file, nothing more, so this change does not affect the docs itself.

We can use this site manifest down the road for partial builds, allowing faster dev cycles and possibly docs previews in the operator repositories.