### PR TITLE
Add flakes as experimental feature to Nix config

### DIFF
--- a/modules/contributor/pages/testing-on-kubernetes.adoc
+++ b/modules/contributor/pages/testing-on-kubernetes.adoc
@@ -37,6 +37,14 @@ After this is done you also need to add a setting to your Nix config in `/etc/ni
 experimental-features = nix-command flakes
 ----
 
+It is also recommend to enable parallel builds by also adding the following config:
+----
+max-jobs = 24
+cores = 8
+----
+
+Please adjust the number of `cores` to your system and set the `max-jobs` to e.g. the third of that.
+
 Just installing Nix does not affect your system much, as it keeps all its configuration and installed packages separate from other package managers and you won't even notice it is there, unless you actually start using it.
 
 == Using

--- a/modules/contributor/pages/testing-on-kubernetes.adoc
+++ b/modules/contributor/pages/testing-on-kubernetes.adoc
@@ -34,7 +34,7 @@ If you don't want to run an arbitrary shellscript directly from the web, have a 
 
 After this is done you also need to add a setting to your Nix config in `/etc/nix/nix.conf`:
 ----
-experimental-features = nix-command
+experimental-features = nix-command flakes
 ----
 
 Just installing Nix does not affect your system much, as it keeps all its configuration and installed packages separate from other package managers and you won't even notice it is there, unless you actually start using it.

--- a/modules/contributor/pages/testing-on-kubernetes.adoc
+++ b/modules/contributor/pages/testing-on-kubernetes.adoc
@@ -37,7 +37,7 @@ After this is done you also need to add a setting to your Nix config in `/etc/ni
 experimental-features = nix-command flakes
 ----
 
-It is also recommend to enable parallel builds by also adding the following config:
+It is also recommended to enable parallel builds by also adding the following configs:
 ----
 max-jobs = 24
 cores = 8


### PR DESCRIPTION
Fixes

```
trino-operat… │ Running cmd: make regenerate-nix && nix-build . -A docker --argstr dockerName "${EXPECTED_REGISTRY}/trino-operator" && ./result/load-image | docker load
trino-operat… │ make[1]: Entering directory '/home/sbernauer/stackabletech/trino-operator'
trino-operat… │ nix run -f . regenerateNixLockfiles
trino-operat… │ error:
trino-operat… │        … while calling the 'derivationStrict' builtin
trino-operat… │ 
trino-operat… │          at /derivation-internal.nix:9:12:
trino-operat… │ 
trino-operat… │             8|
trino-operat… │             9|   strict = derivationStrict drvAttrs;
trino-operat… │              |            ^
trino-operat… │            10|
trino-operat… │ 
trino-operat… │        … while evaluating derivation 'regenerate-nix-lockfiles'
trino-operat… │          whose name attribute is located at /nix/store/gm0k19k4131pblz3pji7dzbc27zm0pv0-nixpkgs-src/pkgs/stdenv/generic/make-derivation.nix:331:7
trino-operat… │ 
trino-operat… │        … while evaluating attribute 'text' of derivation 'regenerate-nix-lockfiles'
trino-operat… │ 
trino-operat… │          at /nix/store/gm0k19k4131pblz3pji7dzbc27zm0pv0-nixpkgs-src/pkgs/build-support/trivial-builders/default.nix:103:16:
trino-operat… │ 
trino-operat… │           102|       ({
trino-operat… │           103|         inherit text executable checkPhase allowSubstitutes preferLocalBuild;
trino-operat… │              |                ^
trino-operat… │           104|         passAsFile = [ "text" ]
trino-operat… │ 
trino-operat… │        error: attribute 'fetchTree' missing
trino-operat… │ 
trino-operat… │        at /nix/store/xnxmzwkgf4vnq2vhivk7mzrg3vmsasqw-crate2nix-src/crate2nix/default.nix:6:15:
trino-operat… │ 
trino-operat… │             5|     in
trino-operat… │             6|     import "${builtins.fetchTree flakeLock.nodes.nixpkgs.locked}" { }
trino-operat… │              |               ^
trino-operat… │             7|   )
trino-operat… │ make[1]: *** [Makefile:147: regenerate-nix] Error 1
trino-operat… │ make[1]: Leaving directory '/home/sbernauer/stackabletech/trino-operator'
```