### PR TITLE
Adjust signature verification policy

### DIFF
--- a/modules/guides/examples/verify-signatures/stackable-image-policy.yaml
+++ b/modules/guides/examples/verify-signatures/stackable-image-policy.yaml
@@ -10,6 +10,6 @@ spec:
         url: https://fulcio.sigstore.dev
         identities:
           - issuer: https://token.actions.githubusercontent.com
-            subjectRegExp: "https://github.com/stackabletech/.+/.github/workflows/.+@refs/tags/\\d[\\d\\.]+"
+            subjectRegExp: "^https://github.com/stackabletech/.+/.github/workflows/.+@refs/tags/\\d[\\d\\.]+$"
       ctlog:
         url: https://rekor.sigstore.dev

--- a/modules/guides/examples/verify-signatures/stackable-image-policy.yaml
+++ b/modules/guides/examples/verify-signatures/stackable-image-policy.yaml
@@ -10,6 +10,6 @@ spec:
         url: https://fulcio.sigstore.dev
         identities:
           - issuer: https://token.actions.githubusercontent.com
-            subjectRegExp: "https://github.com/stackabletech/.+/.github/workflows/build.yml@refs.+"
+            subjectRegExp: "https://github.com/stackabletech/.+/.github/workflows/.+@refs/tags/\\d[\\d\\.]+"
       ctlog:
         url: https://rekor.sigstore.dev

--- a/modules/guides/examples/verify-signatures/stackable-sbom-policy.yaml
+++ b/modules/guides/examples/verify-signatures/stackable-sbom-policy.yaml
@@ -10,7 +10,7 @@ spec:
         url: https://fulcio.sigstore.dev
         identities:
           - issuer: https://token.actions.githubusercontent.com
-            subjectRegExp: "https://github.com/stackabletech/.+/.github/workflows/build.yml@refs.+"
+            subjectRegExp: "https://github.com/stackabletech/.+/.github/workflows/.+@refs/tags/\\d[\\d\\.]+"
       ctlog:
         url: https://rekor.sigstore.dev
       attestations:

--- a/modules/guides/examples/verify-signatures/stackable-sbom-policy.yaml
+++ b/modules/guides/examples/verify-signatures/stackable-sbom-policy.yaml
@@ -10,7 +10,7 @@ spec:
         url: https://fulcio.sigstore.dev
         identities:
           - issuer: https://token.actions.githubusercontent.com
-            subjectRegExp: "https://github.com/stackabletech/.+/.github/workflows/.+@refs/tags/\\d[\\d\\.]+"
+            subjectRegExp: "^https://github.com/stackabletech/.+/.github/workflows/.+@refs/tags/\\d[\\d\\.]+$"
       ctlog:
         url: https://rekor.sigstore.dev
       attestations:

--- a/modules/guides/pages/enabling-verification-of-image-signatures.adoc
+++ b/modules/guides/pages/enabling-verification-of-image-signatures.adoc
@@ -39,9 +39,11 @@ Add a label for the namespace where you deployed SDP:
 kubectl label namespace stackable policy.sigstore.dev/include=true
 ----
 
-The Policy Controller checks all newly created Pods in this namespace that run any image matching `+++**+++.stackable.tech/+++**+++` (this matches images provided by Stackable) and ensures that these images have been signed by a Stackable Github Action. If the signature of an image is invalid or missing, the policy will deny the pod creation.
+The Policy Controller checks all newly created Pods in this namespace that run any image matching `+++**+++.stackable.tech/+++**+++` (this matches images provided by Stackable) and ensures that these images have been signed by a Stackable Github Action that was tagged with a version number (meaning that this was a release version). If the signature of an image is invalid or missing, the policy will deny the pod creation.
 For a more detailed explanation of the policy options, please refer to the https://docs.sigstore.dev/policy-controller/overview/#configuring-image-patterns[Sigstore documentation].
 If the `subjectRegExp` field in the policy is changed to something like `https://github.com/test/.+`, the policy will deny the creation of pods with Stackable images because the identity of the subject that signed the image (a Stackable Github Action Workflow) will no longer match the expression specified in the policy.
+
+NOTE: If for some reason you are using our `0.0.0-dev` images, the example policy will deny the creation of Pods with these images. To allow creation of these Pods, you can for example relax the policy by changing the `subjectRegExp` field to  `https://github.com/stackabletech/.+/.github/workflows/.+@refs/tags/.+`. This will only check if an image has been signed by any Github Action of Stackable, regardless of the version. However, this is not recommended for production.
 
 == Verifying image signatures in an air-gapped environment
 

--- a/modules/guides/pages/enabling-verification-of-image-signatures.adoc
+++ b/modules/guides/pages/enabling-verification-of-image-signatures.adoc
@@ -43,7 +43,7 @@ The Policy Controller checks all newly created Pods in this namespace that run a
 For a more detailed explanation of the policy options, please refer to the https://docs.sigstore.dev/policy-controller/overview/#configuring-image-patterns[Sigstore documentation].
 If the `subjectRegExp` field in the policy is changed to something like `https://github.com/test/.+`, the policy will deny the creation of pods with Stackable images because the identity of the subject that signed the image (a Stackable Github Action Workflow) will no longer match the expression specified in the policy.
 
-NOTE: If for some reason you are using our `0.0.0-dev` images, the example policy will deny the creation of Pods with these images. To allow creation of these Pods, you can for example relax the policy by changing the `subjectRegExp` field to  `https://github.com/stackabletech/.+/.github/workflows/.+@refs/tags/.+`. This will only check if an image has been signed by any Github Action of Stackable, regardless of the version. However, this is not recommended for production.
+NOTE: If for some reason you are using our `0.0.0-dev` images, the example policy will deny the creation of Pods with these images. To allow creation of these Pods, you can for example relax the policy by changing the `subjectRegExp` field to `^https://github.com/stackabletech/.+/.github/workflows/.+@refs/tags/.+$`. This will only check if an image has been signed by any Github Action of Stackable, regardless of the version. However, this is not recommended for production.
 
 == Verifying image signatures in an air-gapped environment
 


### PR DESCRIPTION
This PR fixes two things:

1. The policy did not work as intended, since it checked if images were signed by a Github Action with the filename `build.yml`. This is true for our operators, but not for products. So it was possible to install our operators but Pods from products were wrongly blocked from starting (the filename in case of products is `release.yml`). It does not really make sense to check the filename anyway, so I relaxed the regex in that regard.

2. The policy is now more strict in other regards, because it requires that the Github Action was triggered for a commit tagged with a version number (= a release tag). The regex part `@refs/tags/\d[\d\.]+` checks that the tag starts with a digit and that digit is followed by other digits or dots. We could also make it `@refs/tags/\d+\.\d+\.\d+`, the other variant is just a bit more flexible and would for example also allow `24.7` instead of `24.7.0`.
This means that the policy would now by default block the creation of Pods with dev images, even if they are signed. I explained this in the documentation. The example policy is intended for production use with release images only, but the regex can be relaxed to allow dev images as well.