### PR TITLE
fix: added kafka 3.6.2 to deprecated list

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -559,7 +559,7 @@ The following product versions are deprecated and will be removed in a later rel
 
 * Apache Airflow: 2.7.2, 2.7.3
 * Apache Druid: 27.0.0
-* Apache Kafka: 3.5.1, 3.5.2
+* Apache Kafka: 3.5.1, 3.5.2, 3.6.2
 * Apache NiFi: 1.23.2
 * Apache Spark: 3.4.1, 3.5.0
 * Apache Superset: 2.1.1, 3.0.1. 3.0.3


### PR DESCRIPTION
fix: added kafka 3.6.2 to deprecated list