### PR TITLE
docs(release-notes): Add retroactive mention of User Info Fetcher being experimental

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -103,7 +103,8 @@ Documentation::
 
 * Apache Spark: documentation has been added showing how to provision Spark dependencies
 
-* Open Policy Agent: N.B. As mentioned in the release 24.3, we will be actively building out the backends supported by the User Info Fetcher. This feature should be therefore be treated as experimental, as implementation details are subject to change as we consolidate and fine-tune the tool.
+* Open Policy Agent: N.B. As mentioned in the release 24.3, we will be actively building out the backends supported by the User Info Fetcher.
+This feature should be therefore be treated as experimental as we continue to extend and consolidate back-end handling and fine-tune the tool in general.
 
 Other product features::
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -103,6 +103,8 @@ Documentation::
 
 * Apache Spark: documentation has been added showing how to provision Spark dependencies
 
+* Open Policy Agent: N.B. As mentioned in the release 24.3, we will be actively building out the backends supported by the User Info Fetcher. This feature should be therefore be treated as experimental, as implementation details are subject to change as we consolidate and fine-tune the tool.
+
 Other product features::
 
 The following are selected product features provided by new versions available in this release:


### PR DESCRIPTION
Add a note to the release notes about UIF being experimental (since it was announced in 24.3)