### PR TITLE
Add release branches to the playbooks for release 24.7

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -26,6 +26,7 @@ content:
     - url: .
       branches:
         - HEAD
+        - release/24.7
         - release/24.3
         - release/23.11
         - release/23.7
@@ -40,6 +41,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -50,6 +52,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -59,6 +62,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -68,6 +72,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -78,6 +83,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -87,6 +93,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -96,6 +103,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -105,6 +113,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -114,6 +123,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -123,6 +133,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -132,6 +143,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -141,6 +153,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -150,6 +163,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -159,6 +173,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -168,6 +183,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -177,6 +193,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,6 +15,7 @@ content:
     - url: ./
       branches:
         - HEAD
+        - release/24.7
         - release/24.3
         - release/23.11
         - release/23.7
@@ -29,6 +30,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -39,6 +41,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -48,6 +51,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -57,6 +61,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -67,6 +72,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -76,6 +82,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -85,6 +92,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -94,6 +102,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -103,6 +112,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -112,6 +122,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -121,6 +132,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -130,6 +142,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -139,6 +152,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -148,6 +162,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -157,6 +172,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7
@@ -166,6 +182,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.7
         - release-24.3
         - release-23.11
         - release-23.7

--- a/modules/concepts/pages/stackable_resource_requests.adoc
+++ b/modules/concepts/pages/stackable_resource_requests.adoc
@@ -2,7 +2,7 @@
 // WARNING: do not add headers here as they can break the structure of pages
 // that include this file.
 Stackable operators handle resource requests in a sligtly different manner than Kubernetes.
-Resource requests are defined on xref:stacklet.adoc#roles[role] or xref:stacklet.adoc#role-groups[role group] level.
+Resource requests are defined on xref:concepts:stacklet.adoc#roles[role] or xref:concepts:stacklet.adoc#role-groups[role group] level.
 On a role level this means that by default, all workers will use the same resource requests and limits.
 This can be further specified on role group level (which takes priority to the role level) to apply different resources.
 

--- a/modules/concepts/pages/stackable_resource_requests.adoc
+++ b/modules/concepts/pages/stackable_resource_requests.adoc
@@ -2,7 +2,7 @@
 // WARNING: do not add headers here as they can break the structure of pages
 // that include this file.
 Stackable operators handle resource requests in a sligtly different manner than Kubernetes.
-Resource requests are defined on xref:concepts:stacklet.adoc#roles[role] or xref:concepts:stacklet.adoc#role-groups[role group] level.
+Resource requests are defined on xref:stacklet.adoc#roles[role] or xref:stacklet.adoc#role-groups[role group] level.
 On a role level this means that by default, all workers will use the same resource requests and limits.
 This can be further specified on role group level (which takes priority to the role level) to apply different resources.
 

--- a/scripts/publish-new-version.sh
+++ b/scripts/publish-new-version.sh
@@ -145,7 +145,7 @@ publish_branch="publish-$docs_version"
 git checkout -b "$publish_branch"
 
 git add .
-git commit -m "chore: Add release branches to the playbooks for release $docs_version"
+git commit -m "Add release branches to the playbooks for release $docs_version"
 
 # Push the branch if requested
 if [ "$push" = true ]; then

--- a/scripts/publish-new-version.sh
+++ b/scripts/publish-new-version.sh
@@ -145,7 +145,7 @@ publish_branch="publish-$docs_version"
 git checkout -b "$publish_branch"
 
 git add .
-git commit -m "chore: Add release branches to the playbooks for release $docs_version."
+git commit -m "chore: Add release branches to the playbooks for release $docs_version"
 
 # Push the branch if requested
 if [ "$push" = true ]; then

--- a/scripts/publish-new-version.sh
+++ b/scripts/publish-new-version.sh
@@ -145,7 +145,7 @@ publish_branch="publish-$docs_version"
 git checkout -b "$publish_branch"
 
 git add .
-git commit -m "Add release branches to the playbooks for release $docs_version."
+git commit -m "chore: Add release branches to the playbooks for release $docs_version."
 
 # Push the branch if requested
 if [ "$push" = true ]; then


### PR DESCRIPTION
```[tasklist]
### Fixes
- [ ] https://github.com/stackabletech/demos/pull/75
- [ ] https://github.com/stackabletech/hive-operator/pull/496
- [ ] https://github.com/stackabletech/spark-k8s-operator/pull/441
- [ ] todo: add above getting-started fixes to main branch (to maintain the intended consistency) @NickLarsenNZ
- [ ] https://github.com/stackabletech/documentation/pull/636
```