### PR TITLE
fix: invalid reference

### DIFF
--- a/modules/concepts/pages/overview.adoc
+++ b/modules/concepts/pages/overview.adoc
@@ -47,7 +47,7 @@ Learn more about roles: xref:roles-and-role-groups.adoc[]
 [#deployment]
 == Deployment
 
-All operators and products run as containers in a xref:home::kubernetes.adoc[Kubernetes cluster]. The operators are deployed with stackablectl (the Stackable CLI) or Helm.
+All operators and products run as containers in a xref:ROOT:kubernetes.adoc[Kubernetes cluster]. The operators are deployed with stackablectl (the Stackable CLI) or Helm.
 
 image::deployment.drawio.svg[]
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/documentation/pull/635

> [!CAUTION]
> This might be a hack, and maybe the correct way is to use [`:page-aliases: ...`](https://docs.antora.org/antora/latest/page/page-aliases/), but even then since it is broken within each release that would also require PRs for each release.

01387e5958cfb2711efe2900b536aaf3bc48e649 fixes:

```
[16:23:57.555] ERROR (asciidoctor): target of xref not found: home::kubernetes.adoc
    file: modules/concepts/pages/overview.adoc
    source: /home/nick/dev/github.com/stackabletech/documentation/.git (branch: release/24.3)
```

Remaining errors to fix in this PR:

```
[16:23:58.557] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#roles
    file: docs/modules/airflow/pages/usage-guide/storage-resources.adoc
    source: https://github.com/stackabletech/airflow-operator.git (branch: release-24.3 | start path: docs)
[16:23:58.557] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#role-groups
    file: docs/modules/airflow/pages/usage-guide/storage-resources.adoc
    source: https://github.com/stackabletech/airflow-operator.git (branch: release-24.3 | start path: docs)
[16:23:58.642] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#roles
    file: docs/modules/druid/pages/usage-guide/resources-and-storage.adoc
    source: https://github.com/stackabletech/druid-operator.git (branch: release-24.3 | start path: docs)
[16:23:58.643] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#role-groups
    file: docs/modules/druid/pages/usage-guide/resources-and-storage.adoc
    source: https://github.com/stackabletech/druid-operator.git (branch: release-24.3 | start path: docs)
[16:23:58.731] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#roles
    file: docs/modules/hbase/pages/usage-guide/resource-requests.adoc
    source: https://github.com/stackabletech/hbase-operator.git (branch: release-24.3 | start path: docs)
[16:23:58.732] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#role-groups
    file: docs/modules/hbase/pages/usage-guide/resource-requests.adoc
    source: https://github.com/stackabletech/hbase-operator.git (branch: release-24.3 | start path: docs)
[16:23:58.818] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#roles
    file: docs/modules/hdfs/pages/usage-guide/resources.adoc
    source: https://github.com/stackabletech/hdfs-operator.git (branch: release-24.3 | start path: docs)
[16:23:58.818] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#role-groups
    file: docs/modules/hdfs/pages/usage-guide/resources.adoc
    source: https://github.com/stackabletech/hdfs-operator.git (branch: release-24.3 | start path: docs)
[16:23:58.907] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#roles
    file: docs/modules/hive/pages/usage-guide/resources.adoc
    source: https://github.com/stackabletech/hive-operator.git (branch: release-24.3 | start path: docs)
[16:23:58.907] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#role-groups
    file: docs/modules/hive/pages/usage-guide/resources.adoc
    source: https://github.com/stackabletech/hive-operator.git (branch: release-24.3 | start path: docs)
[16:23:58.983] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#roles
    file: docs/modules/kafka/pages/usage-guide/storage-resources.adoc
    source: https://github.com/stackabletech/kafka-operator.git (branch: release-24.3 | start path: docs)
[16:23:58.983] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#role-groups
    file: docs/modules/kafka/pages/usage-guide/storage-resources.adoc
    source: https://github.com/stackabletech/kafka-operator.git (branch: release-24.3 | start path: docs)
[16:23:59.063] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#roles
    file: docs/modules/nifi/pages/usage_guide/resource-configuration.adoc
    source: https://github.com/stackabletech/nifi-operator.git (branch: release-24.3 | start path: docs)
[16:23:59.063] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#role-groups
    file: docs/modules/nifi/pages/usage_guide/resource-configuration.adoc
    source: https://github.com/stackabletech/nifi-operator.git (branch: release-24.3 | start path: docs)
[16:23:59.286] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#roles
    file: docs/modules/spark-k8s/pages/usage-guide/resources.adoc
    source: https://github.com/stackabletech/spark-k8s-operator.git (branch: release-24.3 | start path: docs)
[16:23:59.287] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#role-groups
    file: docs/modules/spark-k8s/pages/usage-guide/resources.adoc
    source: https://github.com/stackabletech/spark-k8s-operator.git (branch: release-24.3 | start path: docs)
[16:23:59.404] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#roles
    file: docs/modules/trino/pages/usage-guide/configuration.adoc
    source: https://github.com/stackabletech/trino-operator.git (branch: release-24.3 | start path: docs)
[16:23:59.405] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#role-groups
    file: docs/modules/trino/pages/usage-guide/configuration.adoc
    source: https://github.com/stackabletech/trino-operator.git (branch: release-24.3 | start path: docs)
[16:23:59.540] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#roles
    file: docs/modules/zookeeper/pages/usage_guide/resource_configuration.adoc
    source: https://github.com/stackabletech/zookeeper-operator.git (branch: release-24.3 | start path: docs)
[16:23:59.540] ERROR (asciidoctor): target of xref not found: concepts:stacklet.adoc#role-groups
    file: docs/modules/zookeeper/pages/usage_guide/resource_configuration.adoc
    source: https://github.com/stackabletech/zookeeper-operator.git (branch: release-24.3 | start path: docs)
```

There will be similar changes needed for other branches.