### PR TITLE
docs: document how to use tab blocks

### DIFF
--- a/modules/contributor/nav.adoc
+++ b/modules/contributor/nav.adoc
@@ -11,6 +11,7 @@
 ** xref:docs/contributing-documentation.adoc[]
 *** xref:docs/overview.adoc[]
 *** xref:docs/style-guide.adoc[]
+*** xref:docs/using-tab-blocks.adoc[]
 *** xref:docs/backporting-changes.adoc[]
 *** xref:docs/releasing-a-new-version.adoc[]
 *** xref:docs/troubleshooting-antora.adoc[]

--- a/modules/contributor/pages/docs/using-tab-blocks.adoc
+++ b/modules/contributor/pages/docs/using-tab-blocks.adoc
@@ -1,0 +1,27 @@
+= Using tab blocks
+:asciidoctor-tabs-gh: https://github.com/asciidoctor/asciidoctor-tabs
+
+The {asciidoctor-tabs-gh}[`asciidoctor/tabs`] extension is installed, so you can use tab blocks.
+An example can be found in the xref:management:stackablectl:installation.adoc[stackablectl installation instructions].
+
+== Syntax example
+
+[,asciidoc]
+----
+[tabs]
+====
+Tab A:: Contents of Tab A.
+
+Tab B::
++
+Contents of Tab B.
+
+Tab C::
++
+--
+Contents of Tab C.
+
+Contains more than one block.
+--
+====
+----

--- a/modules/contributor/pages/docs/using-tab-blocks.adoc
+++ b/modules/contributor/pages/docs/using-tab-blocks.adoc
@@ -4,6 +4,8 @@
 The {asciidoctor-tabs-gh}[`asciidoctor/tabs`] extension is installed, so you can use tab blocks.
 An example can be found in the xref:management:stackablectl:installation.adoc[stackablectl installation instructions].
 
+TIP: Be sure to use different block indicators nested admonition blocks so that they don't conflict with the tab blocks.
+
 == Syntax example
 
 [,asciidoc]


### PR DESCRIPTION
This is an extension feature, I wanted to explicitly document it in the contribution guide