### PR TITLE
fix: Remove redirect_facility to fix broken redirects

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -10,17 +10,15 @@ site:
 # docs: https://docs.antora.org/antora/latest/playbook/configure-urls/
 urls:
   # The symbolic name of the latest stable version, and how to redirect from/to it.
-  # with 'redirect:to', the _actual_ version link is a redirect, and the _actual_ link 
+  # with 'redirect:to', the _actual_ version link is a redirect, and the _actual_ link
   # contains the symbolic name, i.e. stable.
-  # As the user browses the latest docs, there will be 'stable' in the links. Also 
+  # As the user browses the latest docs, there will be 'stable' in the links. Also
   # search engines will see the 'stable' link and index those pages, so if we release
   # a new version, these links will be already in the index, which is good.
   # Linking to the latest version by version number is still possible, and after the
   # latest version is not latest anymore, the redirect is instead the actual URL.
   latest_version_segment: stable
   latest_version_segment_strategy: redirect:to
-  # We deploy our site on netlify, so we use their redirect config mechanism
-  redirect_facility: netlify
 content:
   sources:
     - url: .

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -19,6 +19,8 @@ urls:
   # latest version is not latest anymore, the redirect is instead the actual URL.
   latest_version_segment: stable
   latest_version_segment_strategy: redirect:to
+  # See https://docs.antora.org/antora/latest/playbook/urls-html-extension-style/#html-extension-style-key
+  html_extension_style: indexify
 content:
   sources:
     - url: .


### PR DESCRIPTION
Fixes https://github.com/stackabletech/crddocs/issues/44

This came up in https://github.com/stackabletech/crddocs/issues/44. Initial investigation revealed that the `roles-and-role-groups.html` file was not present in the stable (24.7) and nightly (soon 24.11) version of generated files when using the production antor playbook.

This playbook is used when Netlify deploys the docs using `make netlify-build`. Local builds using `make` on the other hand included the file in both versions and as such, the redirect works.

Finally, the `redirect_facility: netlify` option was identified as the cause. The generated `_redirects` file only contained a redirect from `concepts/roles-and-role-groups.html` to `concepts/stacklet.html`. This matched with the behaviour we experiences when surfing the live site.

Removing this option (and thus using the default facility) potentially fixes the issue. Netlify already provides redirect using the "Pretty URLs" post-processing feature.

References:

- https://docs.antora.org/antora/latest/playbook/urls-redirect-facility/#redirect-facility-key
- https://docs.netlify.com/site-deploys/post-processing/#post-processing-features
- https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file