### PR TITLE
chore: Add release branches to the playbooks for release 24.11

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -26,6 +26,7 @@ content:
     - url: .
       branches:
         - HEAD
+        - release/24.11
         - release/24.7
         - release/24.3
         - release/23.11
@@ -41,6 +42,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -52,6 +54,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -62,6 +65,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -72,6 +76,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -83,6 +88,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -93,6 +99,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -103,6 +110,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -113,6 +121,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -123,6 +132,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -133,6 +143,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -143,6 +154,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -153,6 +165,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -163,6 +176,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -173,6 +187,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -183,6 +198,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -193,6 +209,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,6 +15,7 @@ content:
     - url: ./
       branches:
         - HEAD
+        - release/24.11
         - release/24.7
         - release/24.3
         - release/23.11
@@ -30,6 +31,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -41,6 +43,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -51,6 +54,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -61,6 +65,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -72,6 +77,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -82,6 +88,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -92,6 +99,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -102,6 +110,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -112,6 +121,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -122,6 +132,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -132,6 +143,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -142,6 +154,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -152,6 +165,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -162,6 +176,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -172,6 +187,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11
@@ -182,6 +198,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-24.11
         - release-24.7
         - release-24.3
         - release-23.11


### PR DESCRIPTION
Created by https://github.com/stackabletech/documentation/blob/f512576917edf092c5da60cfd35ec877446e1a1f/scripts/publish-new-version.sh