### PR TITLE
revert: default cluster domain is now `cluster.local` again

### DIFF
--- a/modules/guides/pages/kubernetes-cluster-domain.adoc
+++ b/modules/guides/pages/kubernetes-cluster-domain.adoc
@@ -9,7 +9,9 @@ The cluster domain can be configured using an environment variable `KUBERNETES_C
 This environment variable can be configured via the helm values property `kubernetesClusterDomain` during the installation of the operators.
 
 ```
-helm install <product>-operator stackable-stable/<product>-operator --set kubernetesClusterDomain="my-cluster.local"
+helm install <product>-operator stackable-stable/<product>-operator --set kubernetesClusterDomain="my.domain"
 ```
+
+You can also specify a custom cluster domain with a trailing dot (`my.domain.` instead of `my.domain`) to reduce the number of DNS requests under certain conditions (see https://github.com/stackabletech/issues/issues/656 for details). Note however that support for this is still considered experimental.
 
 If the environment variable `KUBERNETES_CLUSTER_DOMAIN` (or the helm property `kubernetesClusterDomain`) are not set / overriden, the operator will default the cluster domain to `cluster.local`.

--- a/modules/guides/pages/kubernetes-cluster-domain.adoc
+++ b/modules/guides/pages/kubernetes-cluster-domain.adoc
@@ -1,5 +1,5 @@
 = Configuring the Kubernetes cluster domain
-:description: Configure Stackable operators to use a different cluster domain other than 'cluster.local.'.
+:description: Configure Stackable operators to use a different cluster domain other than 'cluster.local'.
 :dns-custom-nameservers: https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/
 :dns-pod-service: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
@@ -9,9 +9,7 @@ The cluster domain can be configured using an environment variable `KUBERNETES_C
 This environment variable can be configured via the helm values property `kubernetesClusterDomain` during the installation of the operators.
 
 ```
-helm install <product>-operator stackable-stable/<product>-operator --set kubernetesClusterDomain="my.domain."
+helm install <product>-operator stackable-stable/<product>-operator --set kubernetesClusterDomain="my-cluster.local"
 ```
 
-Note that if you specify a custom cluster domain we recommend adding a trailing dot (`my.domain.` instead of `my.domain`) to reduce DNS requests (see https://github.com/stackabletech/issues/issues/656 for details).
-
-If the environment variable `KUBERNETES_CLUSTER_DOMAIN` (or the helm property `kubernetesClusterDomain`) are not set / overriden, the operator will default the cluster domain to `cluster.local.`.
+If the environment variable `KUBERNETES_CLUSTER_DOMAIN` (or the helm property `kubernetesClusterDomain`) are not set / overriden, the operator will default the cluster domain to `cluster.local`.


### PR DESCRIPTION
We decided to default to `cluster.local` again as cluster domain and for now only add experimental support for FQDNs.

For details, see related change in operator-rs: https://github.com/stackabletech/operator-rs/pull/947

This reverts commit 37e194dd2d13d9b3f11dd34165b621a1c9fdee62.
