### PR TITLE
chore(kafka): Set productVersion to 3.9.0 in getting_started

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -130,7 +130,7 @@ metadata:
   name: simple-kafka
 spec:
   image:
-    productVersion: 3.8.0
+    productVersion: 3.9.0
   clusterConfig:
     zookeeperConfigMapName: simple-kafka-znode
     tls:


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/968.