### PR TITLE
fix: Refer supported k8s versions to release notes

### DIFF
--- a/modules/ROOT/pages/kubernetes/index.adoc
+++ b/modules/ROOT/pages/kubernetes/index.adoc
@@ -16,11 +16,7 @@ include::partial$supported-kubernetes-distributions.adoc[]
 
 In case a Kubernetes provider needs some special tuning or we have some tips for it, it has a subpage below this page.
 
-In this version of the SDP, the following Kubernetes versions are supported:
-
-include::partial$supported-kubernetes-versions.adoc[]
-
-Consult the xref:release_notes.adoc[release notes] to find out which specific versions are supported for the Stackable Data Platform you are using.
+Consult the xref:release_notes.adoc[release notes] to find out which specific Kubernetes versions are supported for the Stackable Data Platform you are using.
 
 [#local-installation]
 == Installing a testinging/development Kubernetes instance locally

--- a/modules/ROOT/pages/product-information.adoc
+++ b/modules/ROOT/pages/product-information.adoc
@@ -102,9 +102,10 @@ components.
 
 === Kubernetes
 
-A Kubernetes cluster is required to install the Stackable Data Platform. The supported Kubernetes versions are:
+A Kubernetes cluster is required to install the Stackable Data Platform.
+The supported Kubernetes versions for each platform release can be found here:
 
-include::partial$supported-kubernetes-versions.adoc[]
+xref:release-notes.adoc[SDP Release notes]
 
 There are various Kubernetes distributions. Stackable supports:
 

--- a/modules/ROOT/partials/release-notes/release-24.11.adoc
+++ b/modules/ROOT/partials/release-notes/release-24.11.adoc
@@ -333,6 +333,7 @@ These Kubernetes versions are no longer supported:
 
 This release is available in the RedHat Certified Operator Catalog for the following OpenShift versions:
 
+* `4.16`
 * `4.15`
 * `4.14`
 

--- a/modules/ROOT/partials/supported-kubernetes-versions.adoc
+++ b/modules/ROOT/partials/supported-kubernetes-versions.adoc
@@ -1,7 +1,0 @@
-// The Kubernetes versions supported by all operators
-// This is a separate file to refer to the version at multiple places
-// in the documentation
-
-- 1.28
-- 1.27
-- 1.26


### PR DESCRIPTION
For supported Kubernetes versions, refer to the release docs rather have an extra place that needs to be maintained.
See: 

- https://deploy-preview-707--stackable-docs.netlify.app/home/nightly/product-information/#_kubernetes
- https://deploy-preview-707--stackable-docs.netlify.app/home/nightly/kubernetes/#supported-production-distributions

This removes a point of redundancy, but does result in a link to all release info where one might expect to see information pertinent to the current release (which then has to be maintained separately to the release docs).