### PR TITLE
docs(getting_started): Revert NiFi example back to 1.28.1

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -168,7 +168,7 @@ metadata:
   name: simple-nifi
 spec:
   image:
-    productVersion: 2.2.0
+    productVersion: 1.28.1
   clusterConfig:
     listenerClass: external-unstable
     zookeeperConfigMapName: simple-nifi-znode


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/966