### PR TITLE
chore: Add release branches to the playbooks for release 25.3

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -26,6 +26,7 @@ content:
     - url: .
       branches:
         - HEAD
+        - release/25.3
         - release/24.11
         - release/24.7
         - release/24.3
@@ -42,6 +43,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -54,6 +56,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -65,6 +68,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -76,6 +80,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -88,6 +93,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -99,6 +105,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -110,6 +117,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -121,6 +129,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -132,6 +141,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -143,6 +153,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -154,6 +165,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -165,6 +177,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -176,6 +189,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -187,6 +201,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -198,6 +213,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -209,6 +225,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,6 +15,7 @@ content:
     - url: ./
       branches:
         - HEAD
+        - release/25.3
         - release/24.11
         - release/24.7
         - release/24.3
@@ -31,6 +32,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -43,6 +45,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -54,6 +57,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -65,6 +69,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -77,6 +82,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -88,6 +94,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -99,6 +106,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -110,6 +118,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -121,6 +130,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -132,6 +142,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -143,6 +154,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -154,6 +166,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -165,6 +178,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -176,6 +190,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -187,6 +202,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -198,6 +214,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3


### PR DESCRIPTION
> [!CAUTION]
> Manual adjustments on the release/25.3 branch need to be done before this can be merged.

This adds the 25.3 release to the playbook.