### PR TITLE
fix: Adjust branch names in Antora playbooks

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -25,7 +25,7 @@ content:
   sources:
     - url: .
       branches:
-        - HEAD
+        - release/25.3
         - release/24.11
         - release/24.7
         - release/24.3
@@ -41,7 +41,7 @@ content:
     - url: https://github.com/stackabletech/demos.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -53,7 +53,7 @@ content:
     - url: https://github.com/stackabletech/commons-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -64,7 +64,7 @@ content:
     - url: https://github.com/stackabletech/secret-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -75,7 +75,7 @@ content:
     - url: https://github.com/stackabletech/listener-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -87,7 +87,7 @@ content:
     - url: https://github.com/stackabletech/airflow-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -98,7 +98,7 @@ content:
     - url: https://github.com/stackabletech/druid-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -109,7 +109,7 @@ content:
     - url: https://github.com/stackabletech/hbase-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -120,7 +120,7 @@ content:
     - url: https://github.com/stackabletech/hdfs-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -131,7 +131,7 @@ content:
     - url: https://github.com/stackabletech/hive-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -142,7 +142,7 @@ content:
     - url: https://github.com/stackabletech/kafka-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -153,7 +153,7 @@ content:
     - url: https://github.com/stackabletech/nifi-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -164,7 +164,7 @@ content:
     - url: https://github.com/stackabletech/opa-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -175,7 +175,7 @@ content:
     - url: https://github.com/stackabletech/spark-k8s-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -186,7 +186,7 @@ content:
     - url: https://github.com/stackabletech/superset-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -197,7 +197,7 @@ content:
     - url: https://github.com/stackabletech/trino-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -208,7 +208,7 @@ content:
     - url: https://github.com/stackabletech/zookeeper-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -14,7 +14,7 @@ content:
   sources:
     - url: ./
       branches:
-        - HEAD
+        - release/25.3
         - release/24.11
         - release/24.7
         - release/24.3
@@ -30,7 +30,7 @@ content:
     - url: https://github.com/stackabletech/demos.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -42,7 +42,7 @@ content:
     - url: https://github.com/stackabletech/commons-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -53,7 +53,7 @@ content:
     - url: https://github.com/stackabletech/secret-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -64,7 +64,7 @@ content:
     - url: https://github.com/stackabletech/listener-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -76,7 +76,7 @@ content:
     - url: https://github.com/stackabletech/airflow-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -87,7 +87,7 @@ content:
     - url: https://github.com/stackabletech/druid-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -98,7 +98,7 @@ content:
     - url: https://github.com/stackabletech/hbase-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -109,7 +109,7 @@ content:
     - url: https://github.com/stackabletech/hdfs-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -120,7 +120,7 @@ content:
     - url: https://github.com/stackabletech/hive-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -131,7 +131,7 @@ content:
     - url: https://github.com/stackabletech/kafka-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -142,7 +142,7 @@ content:
     - url: https://github.com/stackabletech/nifi-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -153,7 +153,7 @@ content:
     - url: https://github.com/stackabletech/opa-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -164,7 +164,7 @@ content:
     - url: https://github.com/stackabletech/spark-k8s-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -175,7 +175,7 @@ content:
     - url: https://github.com/stackabletech/superset-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -186,7 +186,7 @@ content:
     - url: https://github.com/stackabletech/trino-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3
@@ -197,7 +197,7 @@ content:
     - url: https://github.com/stackabletech/zookeeper-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.3
         - release-24.11
         - release-24.7
         - release-24.3


### PR DESCRIPTION
This is a manual adjustment, which was also required for 24.11, see https://github.com/stackabletech/documentation/commit/fb38737843f6b174127210cd3c69c793f9f37f9f.