### PR TITLE
Update getting-started.adoc - set zookeeper cli port

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -235,11 +235,15 @@ If all has gone well then you will have successfully deployed a Stackable cluste
 
 === Apache ZooKeeper
 
-We can test ZooKeeper by running the ZooKeeper CLI shell. The easiest way to do this is to run the CLI shell on the pod that is running ZooKeeper.
+We can test ZooKeeper by running the ZooKeeper CLI shell. The easiest way to do this is to run the CLI shell on the pod that is running ZooKeeper. It might be necassary to determine and set the port.
 
 [source,bash]
 ----
 kubectl exec -i -t simple-zk-server-primary-0 -- bin/zkCli.sh
+# optional, determine the port
+PORT=$(kubectl get pod simple-zk-server-primary-0 -o=jsonpath='{.spec.containers[0].ports[0].containerPort}')
+echo $PORT
+kubectl exec -i -t simple-zk-server-primary-0 -- bin/zkCli.sh -server localhost:$PORT
 ----
 
 The shell should connect automatically to the ZooKeeper server running on the pod. You can run the `ls /` command to see the list of znodes in the root path, which should include those created by Apache Kafka and Apache NiFi.


### PR DESCRIPTION
In my case the default port was not correct, leading to an error:

```
 % kubectl exec -i -t simple-zk-server-primary-0 -- bin/zkCli.sh                        
Defaulted container "zookeeper" out of: zookeeper, prepare (init)
Connecting to localhost:2181
2025-04-17 12:28:12,064 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:zookeeper.version=3.9.3-${mvngit.commit.id}, built on 2025-03-25 10:20 UTC
2025-04-17 12:28:12,065 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:host.name=simple-zk-server-primary-0.simple-zk-server-primary.default.svc.cluster.local
2025-04-17 12:28:12,065 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:java.version=17.0.14
2025-04-17 12:28:12,065 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:java.vendor=Eclipse Adoptium
2025-04-17 12:28:12,065 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:java.home=/usr/lib/jvm/temurin-17-jre
2025-04-17 12:28:12,066 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:java.class.path=/stackable/apache-zookeeper-3.9.3-bin/bin/../zookeeper-metrics-providers/zookeeper-prometheus-metrics/target/classes:/stackable/apache-zookeeper-3.9.3-bin/bin/../zookeeper-server/target/classes:/stackable/apache-zookeeper-3.9.3-bin/bin/../build/classes:/stackable/apache-zookeeper-3.9.3-bin/bin/../zookeeper-metrics-providers/zookeeper-prometheus-metrics/target/lib/*.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../zookeeper-server/target/lib/*.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../build/lib/*.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/zookeeper-prometheus-metrics-3.9.3.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/zookeeper-jute-3.9.3.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/zookeeper-3.9.3.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/snappy-java-1.1.10.5.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/slf4j-api-1.7.30.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/simpleclient_servlet-0.9.0.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/simpleclient_hotspot-0.9.0.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/simpleclient_common-0.9.0.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/simpleclient-0.9.0.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-transport-native-unix-common-4.1.113.Final.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-transport-native-epoll-4.1.113.Final-linux-x86_64.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-transport-classes-epoll-4.1.113.Final.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-transport-4.1.113.Final.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-tcnative-classes-2.0.66.Final.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-tcnative-boringssl-static-2.0.66.Final.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-tcnative-boringssl-static-2.0.66.Final-windows-x86_64.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-tcnative-boringssl-static-2.0.66.Final-osx-x86_64.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-tcnative-boringssl-static-2.0.66.Final-osx-aarch_64.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-tcnative-boringssl-static-2.0.66.Final-linux-x86_64.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-tcnative-boringssl-static-2.0.66.Final-linux-aarch_64.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-resolver-4.1.113.Final.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-handler-4.1.113.Final.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-common-4.1.113.Final.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-codec-4.1.113.Final.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/netty-buffer-4.1.113.Final.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/metrics-core-4.1.12.1.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/logback-core-1.2.13.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/logback-classic-1.2.13.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/jline-2.14.6.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/jetty-util-ajax-9.4.56.v20240826.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/jetty-util-9.4.56.v20240826.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/jetty-servlet-9.4.56.v20240826.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/jetty-server-9.4.56.v20240826.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/jetty-security-9.4.56.v20240826.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/jetty-io-9.4.56.v20240826.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/jetty-http-9.4.56.v20240826.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/javax.servlet-api-3.1.0.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/jackson-databind-2.15.2.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/jackson-core-2.15.2.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/jackson-annotations-2.15.2.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/commons-io-2.17.0.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/commons-cli-1.5.0.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../lib/audience-annotations-0.12.0.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../zookeeper-*.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../zookeeper-server/src/main/resources/lib/*.jar:/stackable/apache-zookeeper-3.9.3-bin/bin/../conf:
2025-04-17 12:28:12,066 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:java.library.path=/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
2025-04-17 12:28:12,066 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:java.io.tmpdir=/tmp
2025-04-17 12:28:12,066 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:java.compiler=<NA>
2025-04-17 12:28:12,066 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:os.name=Linux
2025-04-17 12:28:12,066 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:os.arch=aarch64
2025-04-17 12:28:12,066 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:os.version=6.12.13-200.fc41.aarch64
2025-04-17 12:28:12,066 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:user.name=stackable
2025-04-17 12:28:12,066 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:user.home=/stackable
2025-04-17 12:28:12,066 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:user.dir=/stackable/apache-zookeeper-3.9.3-bin
2025-04-17 12:28:12,066 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:os.memory.free=222MB
2025-04-17 12:28:12,066 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:os.memory.max=256MB
2025-04-17 12:28:12,066 [myid:] - INFO  [main:o.a.z.Environment@98] - Client environment:os.memory.total=234MB
2025-04-17 12:28:12,067 [myid:] - INFO  [main:o.a.z.ZooKeeper@637] - Initiating client connection, connectString=localhost:2181 sessionTimeout=30000 watcher=org.apache.zookeeper.ZooKeeperMain$MyWatcher@3aeaafa6
2025-04-17 12:28:12,070 [myid:] - INFO  [main:o.a.z.c.X509Util@88] - Setting -D jdk.tls.rejectClientInitiatedRenegotiation=true to disable client-initiated TLS renegotiation
2025-04-17 12:28:12,377 [myid:] - INFO  [main:o.a.z.c.X509Util@110] - Default TLS protocol is TLSv1.3, supported TLS protocols are [TLSv1.3, TLSv1.2, TLSv1.1, TLSv1, SSLv3, SSLv2Hello]
2025-04-17 12:28:12,380 [myid:] - INFO  [main:o.a.z.ClientCnxnSocket@235] - jute.maxbuffer value is 1048575 Bytes
2025-04-17 12:28:12,383 [myid:] - INFO  [main:o.a.z.ClientCnxn@1748] - zookeeper.request.timeout value is 0. feature enabled=false
Welcome to ZooKeeper!
2025-04-17 12:28:12,385 [myid:localhost:2181] - INFO  [main-SendThread(localhost:2181):o.a.z.ClientCnxn$SendThread@1171] - Opening socket connection to server localhost/127.0.0.1:2181.
2025-04-17 12:28:12,385 [myid:localhost:2181] - INFO  [main-SendThread(localhost:2181):o.a.z.ClientCnxn$SendThread@1173] - SASL config status: Will not attempt to authenticate using SASL (unknown error)
2025-04-17 12:28:12,447 [myid:localhost:2181] - WARN  [main-SendThread(localhost:2181):o.a.z.ClientCnxn$SendThread@1302] - Session 0x0 for server localhost/127.0.0.1:2181, Closing socket connection. Attempting reconnect except it is a SessionExpiredException or SessionTimeoutException.
java.net.ConnectException: Connection refused
	at java.base/sun.nio.ch.Net.pollConnect(Native Method)
	at java.base/sun.nio.ch.Net.pollConnectNow(Unknown Source)
	at java.base/sun.nio.ch.SocketChannelImpl.finishConnect(Unknown Source)
	at org.apache.zookeeper.ClientCnxnSocketNIO.doTransport(ClientCnxnSocketNIO.java:344)
	at org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1291)
JLine support is enabled
[zk: localhost:2181(CONNECTING) 0] 2025-04-17 12:28:13,549 [myid:localhost:2181] - INFO  [main-SendThread(localhost:2181):o.a.z.ClientCnxn$SendThread@1171] - Opening socket connection to server localhost/[0:0:0:0:0:0:0:1]:2181.
2025-04-17 12:28:13,550 [myid:localhost:2181] - INFO  [main-SendThread(localhost:2181):o.a.z.ClientCnxn$SendThread@1173] - SASL config status: Will not attempt to authenticate using SASL (unknown error)
2025-04-17 12:28:13,551 [myid:localhost:2181] - WARN  [main-SendThread(localhost:2181):o.a.z.ClientCnxn$SendThread@1302] - Session 0x0 for server localhost/[0:0:0:0:0:0:0:1]:2181, Closing socket connection. Attempting reconnect except it is a SessionExpiredException or SessionTimeoutException.
java.net.ConnectException: Connection refused
	at java.base/sun.nio.ch.Net.pollConnect(Native Method)
	at java.base/sun.nio.ch.Net.pollConnectNow(Unknown Source)
	at java.base/sun.nio.ch.SocketChannelImpl.finishConnect(Unknown Source)
	at org.apache.zookeeper.ClientCnxnSocketNIO.doTransport(ClientCnxnSocketNIO.java:344)
	at org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1291)
command terminated with exit code 130

```