### PR TITLE
chore: update release notes with stackablectl release upgrade instruction

### DIFF
--- a/modules/ROOT/partials/release-notes/release-template.adoc
+++ b/modules/ROOT/partials/release-notes/release-template.adoc
@@ -81,6 +81,17 @@ Of the changes mentioned above, the following are breaking (or could lead to bre
 
 ===== Using stackablectl
 
+====== Upgrade with a single command
+
+Starting with stackablectl Release 1.0.0 the multiple consecutive commands described below can be shortened to just one command, which executes exactly those steps on its own.
+
+[source,console]
+----
+$ stackablectl release upgrade YY.M
+----
+
+====== Upgrade with multiple consecutive commands
+
 Uninstall the `OO.M` release
 
 [source,console]


### PR DESCRIPTION
Follow up to https://github.com/stackabletech/stackable-cockpit/pull/379
Adds single command instruction for release upgrade to the release notes template