### PR TITLE
refactor: Improve branch/release scripts

### DIFF
--- a/scripts/make-release-branch.sh
+++ b/scripts/make-release-branch.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# This script creates a new 'release/{major}.{minor}'  branch for the documetation,
-# off of the 'main' branch. 
+# This script creates a new 'release-{major}.{minor}'  branch for the documetation,
+# off of the 'main' branch.
 #
 # The script reminds you about some pre-requisites before actually running. These are:
 #
 # - Write the release notes for the release and have them committed into main.
-# - Have the main branch checked out, and up to date with origin. 
+# - Have the main branch checked out, and up to date with origin.
 # - Have a clean working directory.
 #
 # This script takes a major.minor.patch version as an argument and
@@ -20,24 +20,27 @@ set -euo pipefail
 # the version is _required_ and -p for push is optional.
 # If you do not push, you have to push manually afterwards with a regular 'git push'
 
+REMOTE_REF="origin/main"
+LOCAL_REF="HEAD"
+
 # ------------------------------
 # Args parsing
 # ------------------------------
 
-version=""
-push=false
+VERSION=""
+PUSH=false
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
-        -v|--version) version="$2"; shift ;;
-        -p|--push) push=true ;;
+        -v|--version) VERSION="$2"; shift ;;
+        -p|--push) PUSH=true ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
 done
 
 # Check if the required version argument is provided
-if [ -z "$version" ]; then
+if [ -z "$VERSION" ]; then
 echo "Usage: make-release-branch.sh -v <version> [-p]"
 echo "The version needs to be provided as <major>.<minor>.<patch>."
 echo "Use -p to automatically push at the end."
@@ -45,18 +48,18 @@ exit 1
 fi
 
 # Validate the version format (major.minor.patch)
-if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "Invalid version format. Please use the major.minor.patch format."
     exit 1
 fi
 
-echo "Settings: Version: $version, Push: $push"
+echo "Settings: Version: $VERSION, Push: $PUSH"
 
-docs_dir="$(dirname "$0")/.."
-antora_yaml=$docs_dir/antora.yml
+DOCS_DIRECTORY="$(dirname "$0")/.."
+ANTORA_YAML_FILE=$DOCS_DIRECTORY/antora.yml
 
 # Extract major.minor part of the version
-docs_version=$(echo "$version" | cut -d. -f1,2)
+DOCS_VERSION=$(echo "$VERSION" | cut -d. -f1,2)
 
 # ------------------------------
 # Checking prerequisites
@@ -66,28 +69,33 @@ docs_version=$(echo "$version" | cut -d. -f1,2)
 echo "Release notes for the new version should already be written and commited to the main branch,"
 echo "so they show up in both the nightly and future versions, as well as the new release branch"
 echo "that is about the be created."
-read -p "Did you already write release notes and merge them into main? (yes/no): " release_notes_answer
+read -r -p "Did you already write release notes and merge them into main? (yes/no): " RELEASE_NOTES_ANSWER
 
 # Convert the user input to lowercase for case-insensitive comparison
-release_notes_answer_lowercase=$(echo "$release_notes_answer" | tr '[:upper:]' '[:lower:]')
+RELEASE_NOTES_ANSWER_LOWERCASE=$(echo "$RELEASE_NOTES_ANSWER" | tr '[:upper:]' '[:lower:]')
 
 # Check the user's response
-if [ "$release_notes_answer_lowercase" != "yes" ]; then
+if [ "$RELEASE_NOTES_ANSWER_LOWERCASE" != "yes" ]; then
     echo "Please write release notes and merge them into main before running this script."
     exit 1
 fi
 
 # Check if on main branch
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$current_branch" != "main" ]; then
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref $LOCAL_REF)
+if [ "$CURRENT_BRANCH" != "main" ]; then
     echo "Not on the main branch. Please switch to the main branch."
     exit 1
 fi
 
 # Check if the branch is up to date with the origin
 git fetch
-if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
-    echo "Your branch is not up to date with the origin main branch. Please pull the latest changes."
+
+if [ "$(git rev-parse $LOCAL_REF)" != "$(git rev-parse $REMOTE_REF)" ]; then
+    echo "Your branch is not up to date with the origin main branch."
+    echo
+    # This lists the local and remote commit hash, commit message, author name and email, and author date
+    git log --format="%C(auto, yellow)%h: %Creset%s by %C(auto,yellow)%an <%ae>%Creset at %C(auto,blue)%ad (%S)" "$LOCAL_REF" -1
+    git log --format="%C(auto, yellow)%h: %Creset%s by %C(auto,yellow)%an <%ae>%Creset at %C(auto,blue)%ad (%S)" "$REMOTE_REF" -1
     exit 1
 fi
 
@@ -100,52 +108,52 @@ fi
 echo "All checks passed. You are on the main branch, up to date with the origin, and the working directory is clean."
 
 # ------------------------------
-# Updating the antora.yaml
+# Updating the antora.yaml file
 # ------------------------------
 
 # Set version key to docs_version
-sed -i "s/^version:.*/version: \"$docs_version\"/" "$antora_yaml"
+sed -i "s/^version:.*/version: \"$DOCS_VERSION\"/" "$ANTORA_YAML_FILE"
 
 # Set prerelease to false
-sed -i "s/^prerelease:.*/prerelease: false/" "$antora_yaml"
+sed -i "s/^prerelease:.*/prerelease: false/" "$ANTORA_YAML_FILE"
 
 # Set crd-docs-version key to the 'version' variable
-sed -i "s/^\(\s*\)crd-docs-version:.*/\1crd-docs-version: \"$version\"/" "$antora_yaml"
+sed -i "s/^\(\s*\)crd-docs-version:.*/\1crd-docs-version: \"$VERSION\"/" "$ANTORA_YAML_FILE"
 
 # Display changes using git diff
-git diff "$antora_yaml"
+git diff "$ANTORA_YAML_FILE"
 
 # ------------------------------
 # Wrap up: commit and push
 # ------------------------------
 
 # Ask the user whether to proceed
-read -p "Do you want to proceed with these changes? (yes/no): " proceed_answer
+read -r -p "Do you want to proceed with these changes? (yes/no): " PROCEED_ANSWER
 
 # Convert the user input to lowercase for case-insensitive comparison
-proceed_answer_lowercase=$(echo "$proceed_answer" | tr '[:upper:]' '[:lower:]')
+PROCEED_ANSWER_LOWERCASE=$(echo "$PROCEED_ANSWER" | tr '[:upper:]' '[:lower:]')
 
 # Check the user's response
-if [ "$proceed_answer_lowercase" != "yes" ]; then
-    echo "Aborted. Nothing was commited."
+if [ "$PROCEED_ANSWER_LOWERCASE" != "yes" ]; then
+    echo "Aborted. Nothing was committed."
     exit 1
 fi
 
 # User wants to proceed
 # Checkout a new branch
-branch_name="release/$docs_version"
-git checkout -b "$branch_name"
+BRANCH_NAME="release-$DOCS_VERSION"
+git checkout -b "$BRANCH_NAME"
 
 # Commit the changes
-git add "$antora_yaml"
-git commit -m "Update version in antora.yml to $version"
+git add "$ANTORA_YAML_FILE"
+git commit -m "chore: Update version in antora.yml to $VERSION"
 
 # Push the branch if requested
-if [ "$push" = true ]; then
+if [ "$PUSH" = true ]; then
     echo "Pushing changes to origin ..."
-    git push origin "$branch_name"
+    git push origin "$BRANCH_NAME"
 else
     echo "Skipping push to origin. You still need to run:"
-    echo "git push origin \"$branch_name\""
+    echo "git push origin \"$BRANCH_NAME\""
     echo "to complete the process."
 fi

--- a/scripts/publish-new-version.sh
+++ b/scripts/publish-new-version.sh
@@ -24,20 +24,20 @@ fi
 # Args parsing
 # ------------------------------
 
-docs_version=""
-push=false
+DOCS_VERSION=""
+PUSH=false
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
-        -v|--version) docs_version="$2"; shift ;;
-        -p|--push) push=true ;;
+        -v|--version) DOCS_VERSION="$2"; shift ;;
+        -p|--push) PUSH=true ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
 done
 
 # Check if the required version argument is provided
-if [ -z "$docs_version" ]; then
+if [ -z "$DOCS_VERSION" ]; then
 echo "Usage: publish-new-version.sh -v <version> [-p]"
 echo "The version needs to be provided as <major>.<minor>."
 echo "Use -p to automatically push at the end."
@@ -45,42 +45,40 @@ exit 1
 fi
 
 # Validate the version format (major.minor.patch)
-if [[ ! "$docs_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+if [[ ! "$DOCS_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
     echo "Invalid version format. Please use the major.minor format."
     exit 1
 fi
 
-# Define the branches to add. The documentation repo uses a '/' while the operators use a '-'
-docs_branch="release/$docs_version"
-operator_branch="release-$docs_version"
+BRANCH="release-$DOCS_VERSION"
 
 # ------------------------------
 # Checking prerequisites
 # ------------------------------
 
 # Check if the release branch exists upstream
-if ! git rev-parse --quiet --verify "$docs_branch" > /dev/null; then
-    echo "Release branch '$docs_branch' is missing upstream in the documentation repository."
-    echo "Please create the $docs_branch branch first using the make-release-branch.sh script."
+if ! git rev-parse --quiet --verify "$BRANCH" > /dev/null; then
+    echo "Release branch '$BRANCH' is missing upstream in the documentation repository."
+    echo "Please create the $BRANCH branch first using the make-release-branch.sh script."
     echo "Aborting."
     exit 1
 fi
 
 echo "Did you create all the release branches in the operators?"
 echo "Did you also create a release branch in the demos repository?"
-read -p "(yes/no): " operators_branches_answer
+read -r -p "(yes/no): " OPERATORS_BRANCHES_ANSWER
 
 # Convert the user input to lowercase for case-insensitive comparison
-operators_branches_answer_lowercase=$(echo "$operators_branches_answer" | tr '[:upper:]' '[:lower:]')
+OPERATORS_BRANCHES_ANSWER_LOWERCASE=$(echo "$OPERATORS_BRANCHES_ANSWER" | tr '[:upper:]' '[:lower:]')
 
-if [ "$operators_branches_answer_lowercase" != "yes" ]; then
+if [ "$OPERATORS_BRANCHES_ANSWER_LOWERCASE" != "yes" ]; then
     echo "Please create all the branches in the operators before proceeding."
     exit 1
 fi
 
 # Check if on main branch
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$current_branch" != "main" ]; then
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "main" ]; then
     echo "Not on the main branch. Please switch to the main branch."
     exit 1
 fi
@@ -106,21 +104,13 @@ echo "All checks passed."
 
 echo "Updating playbooks."
 
-# Define the branches to add. The documentation repo uses a '/' while the operators use a '-'
-docs_branch="release/$docs_version"
-operator_branch="release-$docs_version"
-insert_position=1
-
-docs_dir="$(dirname "$0")/.."
-playbook_files=("$docs_dir/antora-playbook.yml" "$docs_dir/local-antora-playbook.yml")
+DOCS_DIRECTORY="$(dirname "$0")/.."
+PLAYBOOK_FILES=("$DOCS_DIRECTORY/antora-playbook.yml" "$DOCS_DIRECTORY/local-antora-playbook.yml")
 
 # Loop through each playbook file
-for yaml_file in "${playbook_files[@]}"; do
-    # Insert the docs_branch
-    yq ".content.sources[0].branches |= (.[:$insert_position] + [\"$docs_branch\"] + .[$insert_position:])" -i "$yaml_file"
-
-    # Update all the operator and demos sources.
-    yq "with(.content.sources.[]; select(.url |test(\".*(operator|demos).*\")) | .branches |= .[:$insert_position] + [\"$operator_branch\"] + .[$insert_position:])" -i "$yaml_file"
+for yaml_file in "${PLAYBOOK_FILES[@]}"; do
+    # Update all sources except stackable-cockpit.
+    yq "with(.content.sources.[]; select(.url | test(\".*(stackable-cockpit).*\") | not) | .branches |= .[:1] + [\"release-25.7\"] + .[1:])" -i "$yaml_file"
 done
 
 # ------------------------------
@@ -129,35 +119,37 @@ done
 
 # Display changes and ask for user confirmation
 git diff
-read -p "Do you want to proceed with these changes? (yes/no): " proceed_answer
+read -r -p "Do you want to proceed with these changes? (yes/no): " PROCEED_ANSWER
 
 # Convert the user input to lowercase for case-insensitive comparison
-proceed_answer_lowercase=$(echo "$proceed_answer" | tr '[:upper:]' '[:lower:]')
+PROCEED_ANSWER_LOWERCASE=$(echo "$PROCEED_ANSWER" | tr '[:upper:]' '[:lower:]')
 
 # Check the user's response
-if [ "$proceed_answer_lowercase" != "yes" ]; then
-    echo "Aborted. Nothing was commited."
+if [ "$PROCEED_ANSWER_LOWERCASE" != "yes" ]; then
+    echo "Aborted. Nothing was committed."
     exit 1
 fi
 
-publish_branch="publish-$docs_version"
+PR_BRANCH="pr-$DOCS_VERSION"
 
-git checkout -b "$publish_branch"
+git checkout -b "$PR_BRANCH"
 
 git add .
-git commit -m "Add release branches to the playbooks for release $docs_version"
+git commit -m "chore: Add release branches to the playbooks for release $DOCS_VERSION"
 
 # Push the branch if requested
-if [ "$push" = true ]; then
+if [ "$PUSH" = true ]; then
     echo "Pushing changes to origin ..."
-    git push -u origin "$publish_branch"
+    git push -u origin "$PR_BRANCH"
     echo ""
     echo "The changes have been pushed to GitHub!"
+    echo "Raise the PR against the $BRANCH branch."
     echo "Click the link above to create the PR in GitHub, and then verify that the build works with Netlify previews."
     echo "Once the branch is merged, the changes will automatically be deployed and be live."
 else
     echo ""
     echo "Skipping push to origin."
-    echo "Please push the branch manually and create  PR."
+    echo "Please push the branch manually and create PR."
+    echo "Raise the PR against the $BRANCH branch."
     echo "Once the changes are merged, they will automatically be deployed and be live."
 fi


### PR DESCRIPTION
This PR improves a bunch of things:

- The release branches in the documentation repository now finally uses `release-YY.M.X` instead of `release/YY.M.X` to be inline with all other release branches.
- Converts all variable names to uppercase and improves the naming of some of them.
- Reports the commit of `HEAD` and `origin/main` if they are not in sync
- Print out the branch the PR should be raised against