### PR TITLE
chore: Adjust branch names for 25.7

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -25,7 +25,7 @@ content:
   sources:
     - url: .
       branches:
-        - HEAD
+        - release-25.7
         - release/25.3
         - release/24.11
         - release/24.7
@@ -42,7 +42,7 @@ content:
     - url: https://github.com/stackabletech/demos.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -55,7 +55,7 @@ content:
     - url: https://github.com/stackabletech/commons-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -67,7 +67,7 @@ content:
     - url: https://github.com/stackabletech/secret-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -79,7 +79,7 @@ content:
     - url: https://github.com/stackabletech/listener-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -92,7 +92,7 @@ content:
     - url: https://github.com/stackabletech/airflow-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -104,7 +104,7 @@ content:
     - url: https://github.com/stackabletech/druid-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -116,7 +116,7 @@ content:
     - url: https://github.com/stackabletech/hbase-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -128,7 +128,7 @@ content:
     - url: https://github.com/stackabletech/hdfs-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -140,7 +140,7 @@ content:
     - url: https://github.com/stackabletech/hive-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -152,7 +152,7 @@ content:
     - url: https://github.com/stackabletech/kafka-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -164,7 +164,7 @@ content:
     - url: https://github.com/stackabletech/nifi-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -176,7 +176,7 @@ content:
     - url: https://github.com/stackabletech/opa-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -192,7 +192,7 @@ content:
     - url: https://github.com/stackabletech/spark-k8s-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -204,7 +204,7 @@ content:
     - url: https://github.com/stackabletech/superset-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -216,7 +216,7 @@ content:
     - url: https://github.com/stackabletech/trino-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -228,7 +228,7 @@ content:
     - url: https://github.com/stackabletech/zookeeper-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -14,7 +14,7 @@ content:
   sources:
     - url: ./
       branches:
-        - HEAD
+        - release-25.7
         - release/25.3
         - release/24.11
         - release/24.7
@@ -31,7 +31,7 @@ content:
     - url: https://github.com/stackabletech/demos.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -44,7 +44,7 @@ content:
     - url: https://github.com/stackabletech/commons-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -56,7 +56,7 @@ content:
     - url: https://github.com/stackabletech/secret-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -68,7 +68,7 @@ content:
     - url: https://github.com/stackabletech/listener-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -81,7 +81,7 @@ content:
     - url: https://github.com/stackabletech/airflow-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -93,7 +93,7 @@ content:
     - url: https://github.com/stackabletech/druid-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -105,7 +105,7 @@ content:
     - url: https://github.com/stackabletech/hbase-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -117,7 +117,7 @@ content:
     - url: https://github.com/stackabletech/hdfs-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -129,7 +129,7 @@ content:
     - url: https://github.com/stackabletech/hive-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -141,7 +141,7 @@ content:
     - url: https://github.com/stackabletech/kafka-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -153,7 +153,7 @@ content:
     - url: https://github.com/stackabletech/nifi-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -165,7 +165,7 @@ content:
     - url: https://github.com/stackabletech/opa-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -181,7 +181,7 @@ content:
     - url: https://github.com/stackabletech/spark-k8s-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -193,7 +193,7 @@ content:
     - url: https://github.com/stackabletech/superset-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -205,7 +205,7 @@ content:
     - url: https://github.com/stackabletech/trino-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7
@@ -217,7 +217,7 @@ content:
     - url: https://github.com/stackabletech/zookeeper-operator.git
       start_path: docs
       branches:
-        - main
+        - release-25.7
         - release-25.3
         - release-24.11
         - release-24.7


### PR DESCRIPTION
Update branches for all sources, except stackable-cockpit and the OpenSearch operator.

> [!NOTE]
> The build failure is expected. It is not possible to build the docs on a release branch, only from main.