### PR TITLE
chore: Remove OpenSearch from 25.7

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -185,10 +185,6 @@ content:
         - release-23.7
         - release-23.4
         - release-23.1
-    - url: https://github.com/stackabletech/opensearch-operator.git
-      start_path: docs
-      branches:
-        - main
     - url: https://github.com/stackabletech/spark-k8s-operator.git
       start_path: docs
       branches:

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -174,10 +174,6 @@ content:
         - release-23.7
         - release-23.4
         - release-23.1
-    - url: https://github.com/stackabletech/opensearch-operator.git
-      start_path: docs
-      branches:
-        - main
     - url: https://github.com/stackabletech/spark-k8s-operator.git
       start_path: docs
       branches:

--- a/modules/ROOT/pages/product-information.adoc
+++ b/modules/ROOT/pages/product-information.adoc
@@ -28,7 +28,6 @@ Supported products:
 * xref:hdfs:index.adoc[Apache Hadoop HDFS]
 * xref:kafka:index.adoc[Apache Kafka]
 * xref:nifi:index.adoc[Apache Nifi]
-* xref:opensearch:index.adoc[OpenSearch]
 * xref:spark-k8s:index.adoc[Apache Spark] (including xref:spark-k8s:usage-guide/history-server.adoc[Spark History Server])
 * xref:superset:index.adoc[Apache Superset]
 * xref:trino:index.adoc[Trino]

--- a/modules/concepts/pages/stackable_resource_requests.adoc
+++ b/modules/concepts/pages/stackable_resource_requests.adoc
@@ -1,7 +1,7 @@
 // This is meant to be inlined using the "include" directive in other pages.
 // WARNING: do not add headers here as they can break the structure of pages
 // that include this file.
-Stackable operators handle resource requests in a sligtly different manner than Kubernetes.
+Stackable operators handle resource requests in a slightly different manner than Kubernetes.
 Resource requests are defined on xref:concepts:stacklet.adoc#roles[role] or xref:concepts:stacklet.adoc#role-groups[role group] level.
 On a role level this means that by default, all workers will use the same resource requests and limits.
 This can be further specified on role group level (which takes priority to the role level) to apply different resources.

--- a/modules/concepts/pages/stackable_resource_requests.adoc
+++ b/modules/concepts/pages/stackable_resource_requests.adoc
@@ -1,7 +1,7 @@
 // This is meant to be inlined using the "include" directive in other pages.
 // WARNING: do not add headers here as they can break the structure of pages
 // that include this file.
-Stackable operators handle resource requests in a slightly different manner than Kubernetes.
+Stackable operators handle resource requests in a sligtly different manner than Kubernetes.
 Resource requests are defined on xref:concepts:stacklet.adoc#roles[role] or xref:concepts:stacklet.adoc#role-groups[role group] level.
 On a role level this means that by default, all workers will use the same resource requests and limits.
 This can be further specified on role group level (which takes priority to the role level) to apply different resources.

--- a/modules/operators/pages/index.adoc
+++ b/modules/operators/pages/index.adoc
@@ -139,22 +139,6 @@ xref:nifi:index.adoc[Read more]
 ++++
 
 ++++
-<h3 id="opensearch"><a class="anchor" href="#opensearch"></a>OpenSearch</h3>
-++++
-
-OpenSearch is a powerful search and analytics engine built on Apache Lucene.
-
-xref:opensearch:index.adoc[Read more]
-
-++++
-</div>
-++++
-
-++++
-<div class="box">
-++++
-
-++++
 <h3 id="spark"><a class="anchor" href="#spark"></a>Apache Spark</h3>
 ++++
 

--- a/modules/operators/pages/supported_versions.adoc
+++ b/modules/operators/pages/supported_versions.adoc
@@ -38,10 +38,6 @@ include::nifi:partial$supported-versions.adoc[]
 
 include::opa:partial$supported-versions.adoc[]
 
-== OpenSearch
-
-include::opensearch:partial$supported-versions.adoc[]
-
 == Apache Spark on Kubernetes
 
 include::spark-k8s:partial$supported-versions.adoc[]

--- a/modules/operators/partials/operator_doc_links.adoc
+++ b/modules/operators/partials/operator_doc_links.adoc
@@ -34,11 +34,6 @@ include::kafka:partial$nav.adoc[]
 --
 include::nifi:partial$nav.adoc[]
 --
-** xref:opensearch:index.adoc[OpenSearch]
-+
---
-include::opensearch:partial$nav.adoc[]
---
 ** xref:spark-k8s:index.adoc[Apache Spark on K8S]
 +
 --

--- a/modules/tutorials/pages/index.adoc
+++ b/modules/tutorials/pages/index.adoc
@@ -21,7 +21,6 @@ Follow any of these guides to get started with a specific product.
 * xref:kafka:getting_started/index.adoc[Stackable Operator for Apache Kafka]
 * xref:nifi:getting_started/index.adoc[Stackable Operator for Apache NiFi]
 * xref:opa:getting_started/index.adoc[Stackable Operator for OpenPolicyAgent]
-* xref:opensearch:getting_started/index.adoc[Stackable Operator for OpenSearch]
 * xref:spark-k8s:getting_started/index.adoc[Stackable Operator for Apache Spark]
 * xref:superset:getting_started/index.adoc[Stackable Operator for Apache Superset]
 * xref:trino:getting_started/index.adoc[Stackable Operator for Trino]

--- a/only-dev-antora-playbook.yml
+++ b/only-dev-antora-playbook.yml
@@ -70,10 +70,6 @@ content:
       start_path: docs
       branches:
         - main
-    - url: https://github.com/stackabletech/opensearch-operator.git
-      start_path: docs
-      branches:
-        - main
     - url: https://github.com/stackabletech/spark-k8s-operator.git
       start_path: docs
       branches:

--- a/supplemental-ui/partials/navbar.hbs
+++ b/supplemental-ui/partials/navbar.hbs
@@ -37,7 +37,6 @@
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "hive/index.html") }}}">Apache Hive</a>
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "kafka/index.html") }}}">Apache Kafka</a>
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "nifi/index.html") }}}">Apache NiFi</a>
-        <a class="navbar-item" href="{{{ relativize (versioned "home" page "opensearch/index.html") }}}">OpenSearch</a>
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "spark-k8s/index.html") }}}">Apache Spark on K8S</a>
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "superset/index.html") }}}">Apache Superset</a>
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "trino/index.html") }}}">Trino</a>

--- a/supplemental-ui/partials/navbar.hbs
+++ b/supplemental-ui/partials/navbar.hbs
@@ -37,19 +37,7 @@
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "hive/index.html") }}}">Apache Hive</a>
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "kafka/index.html") }}}">Apache Kafka</a>
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "nifi/index.html") }}}">Apache NiFi</a>
-        {{#if (not (or
-            (eq page.version "23.1")
-            (eq page.version "23.4")
-            (eq page.version "23.7")
-            (eq page.version "23.11")
-            (eq page.version "24.3")
-            (eq page.version "24.7")
-            (eq page.version "24.11")
-            (eq page.version "25.3")
-            (eq page.version "25.7")
-        ))}}
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "opensearch/index.html") }}}">OpenSearch</a>
-        {{/if}}
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "spark-k8s/index.html") }}}">Apache Spark on K8S</a>
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "superset/index.html") }}}">Apache Superset</a>
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "trino/index.html") }}}">Trino</a>

--- a/truly-local-playbook.yml
+++ b/truly-local-playbook.yml
@@ -45,8 +45,6 @@ content:
       start_path: docs
     - url: ../opa-operator/
       start_path: docs
-    - url: ../opensearch-operator/
-      start_path: docs
     - url: ../spark-k8s-operator/
       start_path: docs
     - url: ../superset-operator/


### PR DESCRIPTION
OpenSearch being there led to errors and we don't know why. This is the only solution which made the build work again.