### PR TITLE
chore: Bump zookeeper version for 25.11.0

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -97,7 +97,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   clusterConfig:
     tls:
       serverSecretClass: null


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1275