### PR TITLE
docs: Add artifact registries page

### DIFF
--- a/modules/concepts/nav.adoc
+++ b/modules/concepts/nav.adoc
@@ -1,6 +1,8 @@
 * xref:concepts:index.adoc[]
 ** xref:overview.adoc[Platform overview]
 ** xref:stacklet.adoc[]
+** xref:artifact-registries/index.adoc[]
+*** xref:artifact-registries/container-images.adoc[]
 ** Common configuration mechanisms
 *** xref:product_image_selection.adoc[]
 *** xref:overrides.adoc[Advanced: overrides]
@@ -29,4 +31,3 @@
 ** Maintenance
 *** xref:maintenance/crds.adoc[CRD maintenance]
 *** xref:maintenance/eos.adoc[End-of-Support check]
-** xref:container-images.adoc[]

--- a/modules/concepts/pages/artifact-registries/container-images.adoc
+++ b/modules/concepts/pages/artifact-registries/container-images.adoc
@@ -1,8 +1,9 @@
 = Container images
+:page-aliases: concepts:container-images.adoc
 :ubi: https://catalog.redhat.com/software/base-images
 :stackable-image-registry: https://oci.stackable.tech/
 :stackable-sboms: https://sboms.stackable.tech/
-:description: Overview of Stackable’s container images, including structure, multi-platform support, and why upstream images are not used.
+:description: Overview of Stackable's container images, including structure, multi-platform support, and why upstream images are not used.
 
 The core artifacts of the Stackable Data Platform are container images of Kubernetes operators and the products that these operators deploy.
 

--- a/modules/concepts/pages/artifact-registries/index.adoc
+++ b/modules/concepts/pages/artifact-registries/index.adoc
@@ -1,0 +1,118 @@
+= Artifact registries
+:description: Overview of Stackable's artifact registries where container images and Helm Charts are published to.
+
+Currently, the SDP operator and product container images, as well as the Helm Charts are published on two registries: `oci.stackable.tech` and `quay.io`.
+This page details in which structure these artifacts are stored and can be retrieved.
+
+== oci.stackable.tech
+
+[source,plain]
+----
+oci.stackable.tech
+|- sdp
+|  |- airflow
+|  |- airflow-operator
+|  |- hbase
+|  |- hbase-operator
+|  |- ...
+|- sdp-charts
+   |- airflow-operator
+   |- hbase-operator
+   |- ...
+----
+
+=== Pulling from oci.stackable.tech
+
+* Product container images can be pulled using:
++
+[source,shell]
+----
+$ docker pull oci.stackable.tech/sdp/<PRODUCT>:<VERSION>-stackable<SDP_VERSION>
+----
+* Product operator container images can be pulled using:
++
+[source,shell]
+----
+$ docker pull oci.stackable.tech/sdp/<PRODUCT>-operator:<SDP_VERSION>
+----
+* Product operator Helm Charts can be installed using:
++
+[source,shell]
+----
+$ helm install <PRODUCT>-operator oci://oci.stackable.tech/sdp-charts/<PRODUCT>-operator \
+    --version <SDP_VERSION> \
+    --wait
+----
+
+== quay.io
+
+Currently, only the operator and product container images are published to quay.io by mirroring them from our Harbor instance on `oci.stackable.tech`.
+
+[source,plain]
+----
+quay.io
+|- stackable
+   |- airflow
+   |- airflow-operator
+   |- hbase
+   |- hbase-operator
+   |- ...
+----
+
+=== Pulling from quay.io
+
+* Product container images can be pulled using:
++
+[source,shell]
+----
+$ docker pull quay.io/stackable/<PRODUCT>:<VERSION>-stackable<SDP_VERSION>
+----
+* Product operator container images can be pulled using:
++
+[source,shell]
+----
+$ docker pull quay.io/stackable/<PRODUCT>-operator:<SDP_VERSION>
+----
+
+// NOTE: This is how it will be going forward.
+// On quay.io, everything is stored under the central `stackable` organization.
+// The rest of the structure is identical compared to `oci.stackable.tech`.
+
+// [source,plain]
+// ----
+// quay.io
+// |- stackable
+//    |- sdp
+//    |  |- airflow
+//    |  |- airflow-operator
+//    |  |- hbase
+//    |  |- hbase-operator
+//    |  |- ...
+//    |- sdp-charts
+//       |- airflow-operator
+//       |- hbase-operator
+//       |- ...
+// ----
+
+// === Pulling from quay.io
+
+// * Product container images can be pulled using:
+// +
+// [source,shell]
+// ----
+// $ docker pull quay.io/stackable/sdp/<PRODUCT>:<VERSION>-stackable<SDP_VERSION>
+// ----
+// * Product operator container images can be pulled using:
+// +
+// [source,shell]
+// ----
+// $ docker pull quay.io/stackable/sdp/<PRODUCT>-operator:<SDP_VERSION>
+// ----
+// * Product operator Helm Charts can be installed using:
+// +
+// [source,shell]
+// ----
+// $ helm install <PRODUCT>-operator oci://quay.io/stackable/sdp-charts/<PRODUCT>-operator \
+//     --version <SDP_VERSION> \
+//     --wait
+// ----

--- a/modules/concepts/pages/artifact-registries/index.adoc
+++ b/modules/concepts/pages/artifact-registries/index.adoc
@@ -1,8 +1,8 @@
 = Artifact registries
 :description: Overview of Stackable's artifact registries where container images and Helm Charts are published to.
 
-Currently, the SDP operator and product container images, as well as the Helm Charts are published on two registries: `oci.stackable.tech` and `quay.io`.
-This page details in which structure these artifacts are stored and can be retrieved.
+The SDP operator and product container images, as well as the Helm Charts are published on two registries: `oci.stackable.tech` and `quay.io`.
+This page details in which structure these artifacts are stored and how they can be retrieved.
 
 == oci.stackable.tech
 
@@ -47,6 +47,7 @@ $ helm install <PRODUCT>-operator oci://oci.stackable.tech/sdp-charts/<PRODUCT>-
 == quay.io
 
 Currently, only the operator and product container images are published to quay.io by mirroring them from our Harbor instance on `oci.stackable.tech`.
+See link:#pulling-quay-io[below].
 
 [source,plain]
 ----
@@ -59,6 +60,7 @@ quay.io
    |- ...
 ----
 
+[#pulling-quay-io]
 === Pulling from quay.io
 
 * Product container images can be pulled using:


### PR DESCRIPTION
This came out of https://github.com/stackabletech/issues/issues/716 and [SUP-336](https://stackable.atlassian.net/browse/SUP-336).

This documents the concrete structure of our artifacts on `oci.stackable.tech` and `quay.io`.