### PR TITLE
fix: Fix broken links and add redirect for external sites referencing old release notes link

### DIFF
--- a/modules/contributor/pages/adr/ADR029-database-connection.adoc
+++ b/modules/contributor/pages/adr/ADR029-database-connection.adoc
@@ -255,7 +255,7 @@ druid.metadata.storage.connector.password=druid
 
 2.) Apache Superset
 
-NOTE: Superset supports a very wide range of database systems as described https://superset.apache.org/docs/databases/installing-database-drivers[here]. Not all of them are suitable for metadata storage.
+NOTE: Superset supports a very wide range of database systems as described https://superset.apache.org/user-docs/databases/#installing-database-drivers[here]. Not all of them are suitable for metadata storage.
 
 Connections to Apache Hive, Apache Druid and Trino clusters deployed as part of the SDP platform can be automated by using discovery configuration maps. In this case, the only attribute to configure is the name of the discovery config map of the appropriate system.
 

--- a/modules/contributor/pages/adr/ADR034-foundation-webhooks-deployment.adoc
+++ b/modules/contributor/pages/adr/ADR034-foundation-webhooks-deployment.adoc
@@ -230,5 +230,5 @@ Chosen <<option5>>, because it fits on all decision drivers.
 
 == Links
 
-- ADR https://docs.stackable.tech/home/nightly/contributor/adr/adr034-foundation-webhooks-ca-bundle.adoc[CA bundle injection]
+- ADR https://docs.stackable.tech/home/nightly/contributor/adr/adr033-foundation-webhooks-ca-bundle.adoc[CA bundle injection]
 - https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/[Kubernetes CRD versioning]

--- a/modules/contributor/partials/current_adrs.adoc
+++ b/modules/contributor/partials/current_adrs.adoc
@@ -29,5 +29,6 @@
 **** xref:adr/ADR030-allowed-pod-disruptions.adoc[]
 **** xref:adr/ADR031-resource-labels.adoc[]
 **** xref:adr/ADR032-oidc-support.adoc[]
+**** xref:adr/ADR033-foundation-webhooks-ca-bundle.adoc[]
 **** xref:adr/ADR034-foundation-webhooks-deployment.adoc[]
 **** xref:adr/ADR035-user-info-fetcher.adoc[]

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,8 @@
   from = "/home/stable/reference/*"
   to = "https://crds.stackable.tech/"
   status = 301
+
+[[redirects]]
+  from = "/home/stable/release_notes.html"
+  to = "/home/stable/release-notes"
+  status = 301


### PR DESCRIPTION
Fix broken links and add a redirect to `netlify.toml` for external sites referencing the old URL with `.html` suffix