### PR TITLE
chore: Remove references to Stackable Cockpit (backport of #841)

### DIFF
--- a/modules/ROOT/nav2.adoc
+++ b/modules/ROOT/nav2.adoc
@@ -1,3 +1,2 @@
 * Management
 ** xref:management:stackablectl:index.adoc[]
-** xref:management:cockpit:index.adoc[]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -132,10 +132,9 @@ Read the CustomResourceDefinition (CRD) reference for all CRDs that are deployed
 <h3>Tooling</h3>
 ++++
 
-Learn more about the tooling that supports the Stackable Data Platform; the `stackablectl` CLI utility and the Stackable Cockpit Web UI.
+Learn more about `stackablectl`, the CLI utility for the Stackable Data Platform.
 
 * xref:management:stackablectl:index.adoc[stackablectl]
-* xref:management:cockpit:index.adoc[Cockpit UI]
 
 ++++
 </div>

--- a/modules/ROOT/pages/quickstart.adoc
+++ b/modules/ROOT/pages/quickstart.adoc
@@ -1,6 +1,5 @@
 = Quickstart
 :latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-24.11.1
-:cockpit-releases: https://github.com/stackabletech/stackable-cockpit/releases
 :description: Quickstart guide for Stackable: Install stackablectl, set up a demo, and connect to services like Superset and Trino with easy commands and links.
 
 This is the super-short getting started guide that should enable you to get something up and running in less than three

--- a/modules/concepts/pages/labels.adoc
+++ b/modules/concepts/pages/labels.adoc
@@ -4,7 +4,7 @@
 
 Labels are key/value pairs in the metadata of Kubernetes objects that add identifying information to the object.
 They do not have direct semantic implications but can be used to organize and manage resources.
-The xref:management:stackablectl:index.adoc[`stackablectl`] tool, the cockpit, and the Helm Charts add labels to the resources that are part of a xref:stacklet.adoc[Stacklet], and the operators add labels to the resources they create.
+The xref:management:stackablectl:index.adoc[`stackablectl`] tool and the Helm Charts both add labels to the resources that are part of a xref:stacklet.adoc[Stacklet]. The operators add labels to the resources they create.
 
 == Resource labels added by the operators
 

--- a/modules/contributor/pages/docs/overview.adoc
+++ b/modules/contributor/pages/docs/overview.adoc
@@ -76,7 +76,7 @@ Have a look at the existing getting started guides on how to do this.
 == Templating
 
 There is a templating mechanism in the docs.
-This has been introduced to template in mostly version numbers, so the updating doesn't have to be done by hand. 
+This has been introduced to template in mostly version numbers, so the updating doesn't have to be done by hand.
 
 Every Operator repo has a script `scripts/docs_templating.sh` and a file with templating variables `docs/templating_vars.yaml`.
 The script applies the variables to all `.j2` files in the `docs` directory.
@@ -89,7 +89,7 @@ Without this templating mechanism, every release these values would need to be u
 
 The documentation consists of two _components_, the `home` and `management` component.
 All documentation for the operators is in the `home` component, and it is versioned with the platform versions (23.11, 24.3, 24.7 etc.).
-The `management` component contains docs for `stackablectl` and the Stackable cockpit; it is not versioned (there is only a single, current version).
+The `management` component contains the docs for `stackablectl`. It is not versioned (there is only a single, current version).
 
 The `home` component is actually a {antora-distributed-components}[distributed component], which means that it is split across multiple repositories.
 Each operator repository has a `docs` directory where the docs are found, and in there the `antora.yml` file specifies that the component is `home`, which means that the `home` component is partially defined across all operator repositories.

--- a/modules/contributor/pages/project-overview.adoc
+++ b/modules/contributor/pages/project-overview.adoc
@@ -41,9 +41,9 @@ The actual product artifacts are pulled from the <<product-artifacts, product ar
 The images are pushed into an <<docker-images, image registry>>.
 
 [[management-tooling]]
-=== Management tooling: stackablectl, stackable-cockpit
+=== Management tooling: stackablectl
 
-The `stackablectl` commandline tool and the Stackable Cockpit UI are both found in the https://github.com/stackabletech/stackable-cockpit[stackable-cockpit] repository, and they both share some code.
+The `stackablectl` commandline tool lives in the https://github.com/stackabletech/stackable-cockpit[stackable-cockpit] repository.
 The structure of the repository is documented in its README.
 
 [[documentation]]
@@ -137,7 +137,6 @@ the `sdp` project, run this command:
 ----
 $ curl -X GET --header 'Accept: application/json' 'https://oci.stackable.tech/api/v2.0/projects/sdp/repositories?page=1' | jq --raw-output '.[] | .name'
 sdp/statsd_exporter
-sdp/stackable-cockpit
 sdp/product1
 sdp/git-sync/git-sync
 sdp/sig-storage/csi-provisioner

--- a/supplemental-ui/partials/navbar.hbs
+++ b/supplemental-ui/partials/navbar.hbs
@@ -51,7 +51,6 @@
 <div class="navbar-item has-dropdown is-hoverable">
     <a class="navbar-link" href="#">Tools</a>
     <div class="navbar-dropdown">
-        <a class="navbar-item" href="{{{ relativize (versioned "management" page "cockpit/index.html") }}}">Cockpit</a>
         <a class="navbar-item" href="{{{ relativize (versioned "management" page "stackablectl/index.html") }}}">stackablectl</a>
     </div>
 </div>


### PR DESCRIPTION
Backport of #841 to `release/25.3`.