### PR TITLE
chore: Remove references to Stackable Cockpit (backport of #841)

### DIFF
--- a/modules/ROOT/nav2.adoc
+++ b/modules/ROOT/nav2.adoc
@@ -1,3 +1,2 @@
 * Management
 ** xref:management:stackablectl:index.adoc[]
-** xref:management:cockpit:index.adoc[]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -132,10 +132,9 @@ Read the CustomResourceDefinition (CRD) reference for all CRDs that are deployed
 <h3>Tooling</h3>
 ++++
 
-Learn more about the tooling that supports the Stackable Data Platform; the `stackablectl` CLI utility and the Stackable Cockpit Web UI.
+Learn more about `stackablectl`, the CLI utility for the Stackable Data Platform.
 
 * xref:management:stackablectl:index.adoc[stackablectl]
-* xref:management:cockpit:index.adoc[Cockpit UI]
 
 ++++
 </div>

--- a/modules/ROOT/pages/quickstart.adoc
+++ b/modules/ROOT/pages/quickstart.adoc
@@ -1,7 +1,6 @@
 = Quickstart
 
 :latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-1.0.0-rc2
-:cockpit-releases: https://github.com/stackabletech/stackable-cockpit/releases
 
 This is the super-short getting started guide that should enable you to get something up and running in less than three
 minutes (excluding download times).

--- a/supplemental-ui/partials/navbar.hbs
+++ b/supplemental-ui/partials/navbar.hbs
@@ -40,7 +40,6 @@
 <div class="navbar-sub-item drop-down">
     Management
     <div class="drop-down-content">
-        <a class="drop-down-item" href="{{{ relativize (versioned "management" page "cockpit/index.html") }}}">Cockpit</a>
         <a class="drop-down-item" href="{{{ relativize (versioned "management" page "stackablectl/index.html") }}}">stackablectl</a>
     </div>
 </div>


### PR DESCRIPTION
Backport of #841 to `release/24.3`.