### PR TITLE
chore: Remove references to Stackable Cockpit (backport of #841)

### DIFF
--- a/modules/ROOT/pages/quickstart.adoc
+++ b/modules/ROOT/pages/quickstart.adoc
@@ -1,7 +1,6 @@
 = Quickstart
 
 :latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-1.0.0-rc2
-:cockpit-releases: https://github.com/stackabletech/stackable-cockpit/releases
 
 This is the super-short getting started guide that should enable you to get something up and running in less than three
 minutes (excluding download times).

--- a/supplemental-ui/partials/navbar.hbs
+++ b/supplemental-ui/partials/navbar.hbs
@@ -40,7 +40,6 @@
 <div class="navbar-sub-item drop-down">
     Management
     <div class="drop-down-content">
-        <a class="drop-down-item" href="{{{ relativize (versioned "management" page "cockpit/index.html") }}}">Cockpit</a>
         <a class="drop-down-item" href="{{{ relativize (versioned "management" page "stackablectl/index.html") }}}">stackablectl</a>
     </div>
 </div>


### PR DESCRIPTION
Backport of #841 to `release/23.11`.