### PR TITLE
docs(getting_started): Bump ZooKeeper version to 3.9.5

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -97,7 +97,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.4
+    productVersion: 3.9.5
   clusterConfig:
     tls:
       serverSecretClass: null


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1506.