### PR TITLE
chore: Rename stackable-cockpit repository to stackablectl

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -48,7 +48,7 @@ content:
         - release/23.4
         - release/23.1
     # management tools
-    - url: https://github.com/stackabletech/stackable-cockpit.git
+    - url: https://github.com/stackabletech/stackablectl.git
       start_path: docs
       branches: main
     # demos

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -33,7 +33,7 @@ content:
         - release/23.4
         - release/23.1
     # management tools
-    - url: https://github.com/stackabletech/stackable-cockpit.git
+    - url: https://github.com/stackabletech/stackablectl.git
       start_path: docs
       branches: main
     # demos

--- a/modules/ROOT/pages/quickstart.adoc
+++ b/modules/ROOT/pages/quickstart.adoc
@@ -1,5 +1,5 @@
 = Quickstart
-:latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-1.4.0
+:latest-release: https://github.com/stackabletech/stackablectl/releases/tag/stackablectl-1.4.0
 :description: Quickstart guide for Stackable: Install stackablectl, set up a demo, and connect to services like Superset and Trino with easy commands and links.
 
 This is the super-short getting started guide that should enable you to get something up and running in less than three
@@ -16,9 +16,9 @@ rename the file to `stackablectl`. You can also use the following command:
 
 [source,console]
 ----
-wget -O stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.4.0/stackablectl-x86_64-unknown-linux-gnu
+wget -O stackablectl https://github.com/stackabletech/stackablectl/releases/download/stackablectl-1.4.0/stackablectl-x86_64-unknown-linux-gnu
 # or
-curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.4.0/stackablectl-x86_64-unknown-linux-gnu
+curl -L -o stackablectl https://github.com/stackabletech/stackablectl/releases/download/stackablectl-1.4.0/stackablectl-x86_64-unknown-linux-gnu
 ----
 
 Mark the binary as executable:

--- a/modules/ROOT/partials/release-notes/release-23.11.adoc
+++ b/modules/ROOT/partials/release-notes/release-23.11.adoc
@@ -35,14 +35,6 @@ Airflow clusters can now be configured to use Kubernetes executors, whereby pods
 For JVM-based products (i.e. Druid, HBase, HDFS, Hive, Kafka, NiFi, Spark, Trino and ZooKeeper) it is now possible to provide custom security settings that override the default values.
 This allows the user to control things such as DNS lookup caches.
 
-// TODO: Remove this or describe it differently to not be confused with the new Cockpit app
-===== Stackable Cockpit
-This release includes a very early preview version of Stackable Cockpit, a browser-based management tool which interacts with the Stackable data platform to display e.g. deployed stacklets and their status.
-
-// TODO: Same here
-===== stackablectl
-Our command line tool has been re-worked to use the same backbone as Stackable Cockpit: you can find out about the recent enhancements by visiting the online xref:management:stackablectl:index.adoc[documentation].
-
 ===== Listener operator
 The listener-operator was introduced in release 23.1 and the associated ServiceType field in 23.4.
 In this release we introduce configurable ListenerClass _presets_ that map to the service types appropriate for different environments.

--- a/modules/ROOT/partials/release-notes/release-23.11.adoc
+++ b/modules/ROOT/partials/release-notes/release-23.11.adoc
@@ -35,9 +35,11 @@ Airflow clusters can now be configured to use Kubernetes executors, whereby pods
 For JVM-based products (i.e. Druid, HBase, HDFS, Hive, Kafka, NiFi, Spark, Trino and ZooKeeper) it is now possible to provide custom security settings that override the default values.
 This allows the user to control things such as DNS lookup caches.
 
+// TODO: Remove this or describe it differently to not be confused with the new Cockpit app
 ===== Stackable Cockpit
 This release includes a very early preview version of Stackable Cockpit, a browser-based management tool which interacts with the Stackable data platform to display e.g. deployed stacklets and their status.
 
+// TODO: Same here
 ===== stackablectl
 Our command line tool has been re-worked to use the same backbone as Stackable Cockpit: you can find out about the recent enhancements by visiting the online xref:management:stackablectl:index.adoc[documentation].
 

--- a/modules/ROOT/partials/release-notes/release-24.11.adoc
+++ b/modules/ROOT/partials/release-notes/release-24.11.adoc
@@ -310,7 +310,7 @@ The following product versions are no longer supported (although images for rele
 
 ==== stackablectl
 
-* Bump Rust dependencies to fix critical vulnerability in quinn-proto, see https://github.com/advisories/GHSA-vr26-jcq5-fjj8[CVE-2024-45311] (https://github.com/stackabletech/stackable-cockpit/pull/318).
+* Bump Rust dependencies to fix critical vulnerability in quinn-proto, see https://github.com/advisories/GHSA-vr26-jcq5-fjj8[CVE-2024-45311] (https://github.com/stackabletech/stackablectl/pull/318).
 * We now provide additional completions for Nushell and Elvish, support using SOCK5 and HTTP proxies, and have improved the sorting of release versions.
 
 ==== Supported Kubernetes versions

--- a/modules/ROOT/partials/release-notes/release-24.3.adoc
+++ b/modules/ROOT/partials/release-notes/release-24.3.adoc
@@ -164,9 +164,9 @@ The following product versions are no longer supported (although images for rele
 * Apache Superset: 2.1.0
 * Apache ZooKeeper: 3.8.1
 
-==== Cockpit and stackablectl
+==== stackablectl
 
-A new https://github.com/stackabletech/stackable-cockpit[project] called Stackable Cockpit has been started.
+A project called https://github.com/stackabletech/stackablectl[stackablectl] has been started.
 It is a web-based management tool that allows users to interact with the Stackable data platform.
 The repository also contains the `stackablectl` command line tool, which has been refactored for performance and stability.
 

--- a/modules/ROOT/partials/release-notes/release-25.3.adoc
+++ b/modules/ROOT/partials/release-notes/release-25.3.adoc
@@ -183,15 +183,15 @@ The following product versions are no longer supported (although images for rele
 * Demos and stacks are now versioned and the main branch is considered unstable.
   `stackablectl` by default installs the latest stable demo and/or stack.
   A specific release can be targeted by providing the `--release` argument.
-  See https://github.com/stackabletech/stackable-cockpit/pull/340[stackable-cockpit#340].
+  See https://github.com/stackabletech/stackablectl/pull/340[stackablectl#340].
 * Add new argument --chart-source so that operator charts can be pulled either from an OCI registry (the default) or from a index.yaml-based repository.
-  See https://github.com/stackabletech/stackable-cockpit/pull/344[stackable-cockpit#344].
+  See https://github.com/stackabletech/stackablectl/pull/344[stackablectl#344].
 * Use `rustls-native-certs` so that `stackablectl` can be used in environments with internal PKI.
-  See  https://github.com/stackabletech/stackable-cockpit/pull/351[stackable-cockpit#351].
+  See  https://github.com/stackabletech/stackablectl/pull/351[stackablectl#351].
 * Use `heritage` label when looking up the `minio-console` stacklet.
-  See https://github.com/stackabletech/stackable-cockpit/pull/364[stackable-cockpit#364].
+  See https://github.com/stackabletech/stackablectl/pull/364[stackablectl#364].
 * Improve tracing and log output.
-  See https://github.com/stackabletech/stackable-cockpit/pull/365[stackable-cockpit#365].
+  See https://github.com/stackabletech/stackablectl/pull/365[stackablectl#365].
 
 ==== Supported Kubernetes versions
 

--- a/modules/compliance/pages/licenses.adoc
+++ b/modules/compliance/pages/licenses.adoc
@@ -28,7 +28,7 @@ Additional Stackable Operators
 
 == stackablectl
 
-https://github.com/stackabletech/stackable-cockpit/blob/main/LICENSE[License{external-link-icon}^] for stackablectl.
+https://github.com/stackabletech/stackablectl/blob/main/LICENSE[License{external-link-icon}^] for stackablectl.
 
 == Product images
 

--- a/modules/contributor/pages/adr/ADR031-resource-labels.adoc
+++ b/modules/contributor/pages/adr/ADR031-resource-labels.adoc
@@ -13,7 +13,7 @@ v0.1, 2023-08-25
 
 == Context and Problem Statement
 
-This ADR tries to solve a common issue within the SDP. When `stackablectl` (and in the future our Cockpit) deploys
+This ADR tries to solve a common issue within the SDP. When `stackablectl` deploys
 resources into a Kubernetes cluster, we are currently unable to properly identify them afterwards. Adding a common set
 of labels to the resources we deploy will solve this issue. Additionally we will use namespaces to track resources
 deployed together. The following use-cases are then possible:
@@ -133,17 +133,17 @@ The maximum length for both cases is 63 characters.
 
 The following options are available:
 
-* `app.kubernetes.io/managed-by=stackablectl|stackable-cockpit`: Well-known label, however not recommended because Helm
+* `app.kubernetes.io/managed-by=stackablectl|stackablectl`: Well-known label, however not recommended because Helm
   already uses this label to track which resources are managed by Helm. As we use Helm in the background to install some
   of our manifests, we would potentially break Helms (uninstall) behavior.
-* `stackable.tech/managed-by=stackablectl|stackable-cockpit`: Doesn't collide with Helm
-* `stackable.tech/deployed-by=stackablectl|stackable-cockpit`: Alternative to above
+* `stackable.tech/managed-by=stackablectl|stackablectl`: Doesn't collide with Helm
+* `stackable.tech/deployed-by=stackablectl|stackablectl`: Alternative to above
 
 Alternatives are:
 
-* `management.stackable.tech/managed-by=stackablectl|stackable-cockpit`
-* `tools.stackable.tech/managed-by=stackablectl|stackable-cockpit`
-* `mgmt.stackable.tech/managed-by=stackablectl|stackable-cockpit`
+* `management.stackable.tech/managed-by=stackablectl|stackablectl`
+* `tools.stackable.tech/managed-by=stackablectl|stackablectl`
+* `mgmt.stackable.tech/managed-by=stackablectl|stackablectl`
 
 '''
 
@@ -290,5 +290,5 @@ for demo in demos_with_label("demo-*") {
   with `suffix` being optional and the implementation not yet decided on.
 * **Namespacing Stacks and Demos:** Yes, use `stackable-<demo|stack>-<demo-name|stack-name>(-suffix)`
 * **Adding Label to indicate which Management Tool was used:** Yes, use
-  `stackable.tech/managed-by=stackablectl|stackable-cockpit`
+  `stackable.tech/managed-by=stackablectl|stackablectl`
 * **Enabling Custom Labels provided by Users:** No support for now. Add it in the future if this feature is requested.

--- a/modules/contributor/pages/project-overview.adoc
+++ b/modules/contributor/pages/project-overview.adoc
@@ -43,7 +43,7 @@ The images are pushed into an <<docker-images, image registry>>.
 [[management-tooling]]
 === Management tooling: stackablectl
 
-The `stackablectl` commandline tool lives in the https://github.com/stackabletech/stackable-cockpit[stackable-cockpit{external-link-icon}^] repository.
+The `stackablectl` commandline tool lives in the https://github.com/stackabletech/stackablectl[stackablectl{external-link-icon}^] repository.
 The structure of the repository is documented in its README.
 
 [[documentation]]

--- a/only-dev-antora-playbook.yml
+++ b/only-dev-antora-playbook.yml
@@ -22,7 +22,7 @@ content:
       branches:
         - HEAD
     # management tools
-    - url: https://github.com/stackabletech/stackable-cockpit.git
+    - url: https://github.com/stackabletech/stackablectl.git
       start_path: docs
       branches: main
     # demos

--- a/scripts/publish-new-version.sh
+++ b/scripts/publish-new-version.sh
@@ -109,8 +109,8 @@ PLAYBOOK_FILES=("$DOCS_DIRECTORY/antora-playbook.yml" "$DOCS_DIRECTORY/local-ant
 
 # Loop through each playbook file
 for yaml_file in "${PLAYBOOK_FILES[@]}"; do
-    # Update all sources except stackable-cockpit.
-    yq "with(.content.sources.[]; select(.url | test(\".*(stackable-cockpit).*\") | not) | .branches |= .[:1] + [\"$BRANCH\"] + .[1:])" -i "$yaml_file"
+    # Update all sources except stackablectl.
+    yq "with(.content.sources.[]; select(.url | test(\".*(stackablectl).*\") | not) | .branches |= .[:1] + [\"$BRANCH\"] + .[1:])" -i "$yaml_file"
 done
 
 # ------------------------------

--- a/truly-local-playbook.yml
+++ b/truly-local-playbook.yml
@@ -22,7 +22,7 @@ content:
       branches:
         - HEAD
     # management tools
-    - url: ../stackable-cockpit/
+    - url: ../stackablectl/
       start_path: docs
     # demos
     - url: ../demos/


### PR DESCRIPTION
stackablectl has been removed, stackable-cockpit has been renamed to stackablectl, and stackable-ui has been renamed to cockpit.