### PR TITLE
docs: Fix the documentation of JSON config overrides

### DIFF
--- a/modules/concepts/pages/overrides.adoc
+++ b/modules/concepts/pages/overrides.adoc
@@ -86,10 +86,10 @@ The `jsonPatch` is more complicated than the `jsonMergePatch`, but offers more f
 ----
 configOverrides:
   config.json:
-    jsonPatches:
-      - '{"op": "test", "path": "/0/name", "value": "Andrew"}'
-      - '{"op": "add", "path": "/0/happy", "value": true}'
-      - '{"op": "remove", "path": "/0/birthDate"}'
+    jsonPatch:
+      - {"op": "test", "path": "/0/name", "value": "Andrew"}
+      - {"op": "add", "path": "/0/happy", "value": true}
+      - {"op": "remove", "path": "/0/birthDate"}
 ----
 
 ==== User provided JSON
@@ -117,7 +117,8 @@ configOverrides:
   config.json:
     userProvided:
       myString: test
-      myList: [test]
+      myList:
+        - test
       myBool: true
       my:
         nested.field.with.dots: 42


### PR DESCRIPTION
Fix the documentation of JSON config overrides

The description of `jsonPatch` is correct but the example was wrong.

JSON config overrides are currently supported in [OpenSearch](https://docs.stackable.tech/home/nightly/opensearch/usage-guide/configuration-environment-overrides/#_configuration_properties) and the [OpenPolicyAgent](https://docs.stackable.tech/home/nightly/opa/usage-guide/configuration-environment-overrides/#_configuration_properties). The operator specific pages are already correct.