### PR TITLE
feat: Shared link bar partial for operator index pages

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -29,6 +29,9 @@ asciidoc:
     end-of-life: false
     # use the attributes below to link to the CRD docs
     crd-docs-base-url: "https://crds.stackable.tech"
+    # used by the operator index pages, see the
+    # operator-link-bar.adoc partial in the ROOT module
+    hub-base-url: "https://hub.stackable.tech"
     crd-docs: "{crd-docs-base-url}/{crd-docs-version}"
     # to make attributes accessible to the UI template, they need to
     # be prefixed with "page-"

--- a/modules/ROOT/partials/operator-link-bar.adoc
+++ b/modules/ROOT/partials/operator-link-bar.adoc
@@ -1,0 +1,16 @@
+// Shared link bar for operator index pages.
+//
+// Usage in an operator's index.adoc:
+//
+//   :github: https://github.com/stackabletech/airflow-operator/
+//   :crd: {crd-docs-base-url}/airflow-operator/{crd-docs-version}/
+//   :hub: {hub-base-url}/components/airflow
+//
+//   include::ROOT:partial$operator-link-bar.adoc[]
+//
+// Every entry is optional: pages that don't define an attribute don't render
+// its entry (e.g. the internal operators have no Hub component page).
+[.link-bar]
+ifdef::github[* {github}[GitHub {external-link-icon}^]]
+ifdef::crd[* {crd}[CRD documentation {external-link-icon}^]]
+ifdef::hub[* {hub}[Stackable Hub {external-link-icon}^]]


### PR DESCRIPTION
## Description

The link bar at the top of every operator index page (GitHub / Feature Tracker / CRD documentation) is currently copy-pasted in all operator repos. This PR adds a shared partial so the bar is maintained in one place. And it prepares for Hub integration

This is what I mean:
<img width="1389" height="209" alt="image" src="https://github.com/user-attachments/assets/31606ad7-d07b-455e-bb27-0839fcb06f7f" />

- I dropped the Feature Tracker

### How to use

  ```asciidoc
  :github: https://github.com/stackabletech/airflow-operator/
  :crd: {crd-docs-base-url}/airflow-operator/{crd-docs-version}/
  :hub: {hub-base-url}/components/airflow

  include::ROOT:partial$operator-link-bar.adoc[]
  ```

Every attribute is optional
