### PR TITLE
chore: Add rate limiting to whole page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,15 @@
   command = "make netlify-build"
   publish = "build/site"
 
+# Rate limiting across the whole page. 25 request per 60 seconds aggregated by client IP.
+[[redirects]]
+  from = "/*"
+  to = "/:splat"
+    [redirects.rate_limit]
+    window_limit = 25
+    window_size = 60
+    aggregate_by = ["ip"]
+
 [[redirects]]
   from = "/home/stable/reference/*"
   to = "https://hub.stackable.tech/crds"


### PR DESCRIPTION
> [!WARNING]
> We don't actually know if aggregation by IP address is supported by our Netlify tier. So this change might needs to get reverted or adjusted.

This PR adds rate limiting to the complete page. Clients can request 25 times per 60 seconds. The limits are aggregated by client IP address.