### PR TITLE
chore: Add more granular rate limiting

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,15 +2,6 @@
   command = "make netlify-build"
   publish = "build/site"
 
-# Rate limiting across the whole page. 250 request per 60 seconds aggregated by client IP.
-[[redirects]]
-  from = "/*"
-  to = "/:splat"
-    [redirects.rate_limit]
-    window_limit = 250
-    window_size = 60
-    aggregate_by = ["ip"]
-
 [[redirects]]
   from = "/home/stable/reference/*"
   to = "https://hub.stackable.tech/crds"
@@ -20,3 +11,45 @@
   from = "/home/stable/release_notes.html"
   to = "/home/stable/release-notes"
   status = 301
+
+# -------------
+# RATE LIMITING
+# All rate limiting is aggregated by client IP and domain (domain is added automatically by Netlify)
+# Redirects/rules are evaluated from top to bottom and the first match will always be used by Netlify.
+# -------------
+
+#---------------------
+# ASSETS RATE LIMITING
+# These limits can be set higher, because most automated requests/attacks will most likely only
+# request the page itself and not its assets.
+# --------------------
+
+# Rate limit access to assets. This redirect rule/rate limit comes BEFORE the catch-all.
+[[redirects]]
+  from = "/_/*"
+  to = "/_/:splat"
+    [redirects.rate_limit]
+    window_limit = 250
+    window_size = 60
+    aggregate_by = ["ip"]
+
+# Rate limit pagefind (search) resources. This redirect rule/rate limit comes BEFORE the catch-all.
+[[redirects]]
+  from = "/pagefind/*"
+  to = "/pagefind/:splat"
+    [redirects.rate_limit]
+    window_limit = 250
+    window_size = 60
+    aggregate_by = ["ip"]
+
+#------------------------
+# CATCH-ALL RATE LIMITING
+# -----------------------
+
+[[redirects]]
+  from = "/*"
+  to = "/:splat"
+    [redirects.rate_limit]
+    window_limit = 50
+    window_size = 60
+    aggregate_by = ["ip"]


### PR DESCRIPTION
This PR includes the following changes:

- Move rate limiting rules below other, more specific redirect rules
- Add more granular rate limiting rules grouped by
  - assets (250req/min)
  - pagefind assets (250req/min)
  - and a catch-all (50req/min)