### PR TITLE
chore: Only use 2 rate limit rules

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,128 +16,8 @@
 # RATE LIMITING
 # All rate limiting is aggregated by client IP and domain (domain is added automatically by Netlify)
 # Redirects/rules are evaluated from top to bottom and the first match will always be used by Netlify.
+# Our current tier only seems to allow 2 rate limiting rules.
 # -------------
-
-# Rate limit the top most pages
-[[redirects]]
-  from = "/home/stable/spark-k8s/"
-  to = "/home/stable/spark-k8s/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/druid/"
-  to = "/home/stable/druid/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/nifi/"
-  to = "/home/stable/nifi/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/superset/"
-  to = "/home/stable/superset/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/trino/"
-  to = "/home/stable/trino/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/zookeeper/"
-  to = "/home/stable/zookeeper/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/opa/"
-  to = "/home/stable/opa/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/hbase/"
-  to = "/home/stable/hbase/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/airflow/"
-  to = "/home/stable/airflow/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/hive/"
-  to = "/home/stable/hive/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/kafka/"
-  to = "/home/stable/kafka/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/hdfs/"
-  to = "/home/stable/hdfs/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/secret-operator/"
-  to = "/home/stable/secret-operator/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/listener-operator/"
-  to = "/home/stable/listener-operator/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
-
-[[redirects]]
-  from = "/home/stable/commons-operator/"
-  to = "/home/stable/commons-operator/"
-    [redirects.rate_limit]
-    window_limit = 10
-    window_size = 60
-    aggregate_by = ["ip"]
 
 #---------------------
 # ASSETS RATE LIMITING
@@ -154,15 +34,6 @@
     window_size = 60
     aggregate_by = ["ip"]
 
-# Rate limit pagefind (search) resources. This redirect rule/rate limit comes BEFORE the catch-all.
-[[redirects]]
-  from = "/pagefind/*"
-  to = "/pagefind/:splat"
-    [redirects.rate_limit]
-    window_limit = 250
-    window_size = 60
-    aggregate_by = ["ip"]
-
 #------------------------
 # CATCH-ALL RATE LIMITING
 # -----------------------
@@ -171,6 +42,6 @@
   from = "/*"
   to = "/:splat"
     [redirects.rate_limit]
-    window_limit = 50
+    window_limit = 25
     window_size = 60
     aggregate_by = ["ip"]


### PR DESCRIPTION
Sadly, we can only have two rate limiting rules.

A follow-up PR will put the pagefind assets under the `/_/` path with all the other assets, so that the correct rate limiting rule will catch its assets.