### PR TITLE
chore: Place pagefind assets next to other assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "ui"
   ],
   "scripts": {
-    "build-search-index": "npx pagefind --site build/site"
+    "build-search-index": "npx pagefind --site build/site --output-subdir _/pagefind"
   }
 }


### PR DESCRIPTION
> [!NOTE]
> Wait for merge until the submodule has been updated.

This allows us to match requests to pagefind URLs using our asset rate limiting rule instead of the catch-all rule. The pagefind assets were previously /pagefind. Now, they are placed alongside other assets under /_/pagefind.