### PR TITLE
chore: Bump the normal rate limit back to 250

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -42,6 +42,6 @@
   from = "/*"
   to = "/:splat"
     [redirects.rate_limit]
-    window_limit = 25
+    window_limit = 250
     window_size = 60
     aggregate_by = ["ip"]


### PR DESCRIPTION
Netlify is doing something fucky. This basically immediately breaks normal browsing behaviour after 3/4 clicks while it clearly shouldn't.