### PR TITLE
perf: Load fonts with font-display swap, preloads and caching

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,11 @@
   from = "/home/stable/release_notes.html"
   to = "/home/stable/release-notes"
   status = 301
+
+# The bundle file names are not content-hashed, so a stale asset can be
+# served until max-age expires. One hour keeps that window small; with
+# content-hashed file names this could be immutable.
+[[headers]]
+  for = "/_/*"
+  [headers.values]
+    Cache-Control = "public, max-age=3600"

--- a/ui/src/css/fonts.css
+++ b/ui/src/css/fonts.css
@@ -1,13 +1,13 @@
 /* How do fonts work in this build setup?
  * Fonts are installed from fontsource packages.
- * In the file ./gulp.d/tasks/build.js there is an action that copies the font files
- * from the installed packages into the output directory, based on matching file names.
- * search for 'fontsource' in the file, and you will find a post CSS action.
+ * The build (ui/build.mjs) resolves the ~@fontsource urls below and emits the
+ * font files into the bundle's font/ directory.
  */
 
 /* Noto Sans - the base font for the body */
 
 @font-face {
+  font-display: swap;
   font-family: "Noto Sans";
   font-style: normal;
   font-weight: 400;
@@ -17,6 +17,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: "Noto Sans";
   font-style: normal;
   font-weight: 700;
@@ -28,6 +29,7 @@
 /* IMB Plex Mono - the header font */
 
 @font-face {
+  font-display: swap;
   font-family: "IBM Plex Mono";
   font-style: normal;
   font-weight: 400;
@@ -37,6 +39,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: "IBM Plex Mono";
   font-style: normal;
   font-weight: 600;
@@ -48,6 +51,7 @@
 /* Noto Sans Mono - The monospace font for code blocks */
 
 @font-face {
+  font-display: swap;
   font-family: "Noto Sans Mono";
   font-style: normal;
   font-weight: 400;
@@ -57,6 +61,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: "Noto Sans Mono";
   font-style: normal;
   font-weight: 500;

--- a/ui/src/partials/head-styles.hbs
+++ b/ui/src/partials/head-styles.hbs
@@ -1,2 +1,4 @@
+    <link rel="preload" href="{{{uiRootPath}}}/font/noto-sans-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="{{{uiRootPath}}}/font/ibm-plex-mono-latin-600-normal.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
     <link rel="stylesheet" href="/pagefind/pagefind-modular-ui.css">


### PR DESCRIPTION
## Description

I did run a [Google Lighthouse/PageSpeed](https://pagespeed.web.dev/) check over the docs site and had Claude help me with fixing some of the issues, namely these two:

<img width="1006" height="1160" alt="image" src="https://github.com/user-attachments/assets/d4c2617e-1a13-4140-a42b-e5c9e1f0a113" />

* Font display by using `font-display: swap`: text renders immediately in the fallback font instead of waiting for webfonts (Lighthouse estimates ~400 ms).
* Partially: Network depenency tree: By preloading the two important fonts, so the swapping (above) should usually not even hit
* Use efficient cache lifetimes: Cache-Control: max-age=3600. One hour only: the bundle file names aren't content-hashed yet, so I didn't want to go any higher. My plan is to use content-hashing in the future. Especially now with bunny in front that should make things easier.

