### PR TITLE
fix: Move pagefind assets back to /pagefind to fix broken search

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ui"
   ],
   "scripts": {
-    "build-search-index": "npx pagefind --site build/site --output-subdir _/pagefind"
+    "build-search-index": "npx pagefind --site build/site"
   },
   "engines": {
     "node": ">= 24.0.0"

--- a/ui/src/partials/head-scripts.hbs
+++ b/ui/src/partials/head-scripts.hbs
@@ -22,4 +22,4 @@
     -->
     {{/with}}
     <script>var uiRootPath = '{{{uiRootPath}}}'</script>
-    <script src="/_/pagefind/pagefind-modular-ui.js"></script>
+    <script src="/pagefind/pagefind-modular-ui.js"></script>

--- a/ui/src/partials/head-styles.hbs
+++ b/ui/src/partials/head-styles.hbs
@@ -1,2 +1,2 @@
     <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
-    <link rel="stylesheet" href="/_/pagefind/pagefind-modular-ui.css">
+    <link rel="stylesheet" href="/pagefind/pagefind-modular-ui.css">


### PR DESCRIPTION
#883 moved the pagefind bundle from `/pagefind/` to `/_/pagefind/` so its requests would match the asset rate-limit rule. But pagefind derives its result baseUrl by stripping the `/pagefind/` suffix off the bundle path. With the bundle at `/_/pagefind/`, the derived baseUrl became `/_/`, which got prepended to every search result URL.

Rate limiting was removed entirely in #885, so #883 no longer serves any purpose. This reverts the bundle back to `/pagefind/`.