### PR TITLE
chore: Add release branches to the playbooks for release 26.7

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -37,6 +37,7 @@ content:
     - url: .
       branches:
         - HEAD
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -57,6 +58,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -73,6 +75,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -88,6 +91,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -103,6 +107,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -119,6 +124,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -134,6 +140,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -149,6 +156,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -164,6 +172,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -179,6 +188,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -194,6 +204,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -209,6 +220,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -224,6 +236,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -239,12 +252,14 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
     - url: https://github.com/stackabletech/spark-k8s-operator.git
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -260,6 +275,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -275,6 +291,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -290,6 +307,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -22,6 +22,7 @@ content:
     - url: ./
       branches:
         - HEAD
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -42,6 +43,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -58,6 +60,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -73,6 +76,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -88,6 +92,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -104,6 +109,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -119,6 +125,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -134,6 +141,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -149,6 +157,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -164,6 +173,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -179,6 +189,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -194,6 +205,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -209,6 +221,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -224,12 +237,14 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
     - url: https://github.com/stackabletech/spark-k8s-operator.git
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -245,6 +260,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -260,6 +276,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7
@@ -275,6 +292,7 @@ content:
       start_path: docs
       branches:
         - main
+        - release-26.7
         - release-26.3
         - release-25.11
         - release-25.7


### PR DESCRIPTION
Part of https://github.com/stackabletech/documentation/pull/893.