### PR TITLE
fix: Make netlify-fetch immune to stale cached release branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,10 @@ netlify-fetch:
 	# race the ref updates and silently leave a stale local branch behind,
 	# which only surfaces much later as a missing-object error from antora.
 	# Failures abort the build immediately instead.
-	set -e; for branch in $$(git ls-remote --heads origin | sed 's|.*refs/heads/||' | grep -E 'release[/-]'); do \
+	set -eu; \
+	branches="$$(git ls-remote --heads origin | sed 's|.*refs/heads/||' | grep -E 'release[/-]')"; \
+	[ -n "$$branches" ] || { echo "netlify-fetch: no release branches from ls-remote - refusing to continue"; exit 1; }; \
+	for branch in $$branches; do \
 		git -c gc.auto=0 fetch origin "+refs/heads/$$branch:refs/heads/$$branch"; \
 		git -c gc.auto=0 checkout -q "$$branch" -- . ; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -54,20 +54,25 @@ clean:
 	rm -rf cache
 
 # The netlify repo is checked out without any blobs. Antora needs local
-# release branches and their blobs in the object database, so this target
-# creates/updates the local branches and materializes their blobs via
-# pathspec checkouts - without ever switching HEAD (enabling branch previews!).
-# ui/ is excluded: release branches still reference it as a submodule and
-# its blobs are not needed (the UI bundle is built from the current checkout).
+# release branches and their complete tip trees in the object database (it
+# reads them with isomorphic-git, which cannot fetch missing objects on
+# demand), so this target creates/updates the local branches and
+# materializes their blobs via pathspec checkouts - without ever switching
+# HEAD (enabling branch previews!).
 netlify-fetch:
 	# netlify messes with some files, restore everything to how it was:
 	git reset --hard
 	# fetch, because netlify does caching and we want to get the latest commits
-	git fetch --all
-	for remote in $(shell git branch -r | grep -E 'release[/-]'); do \
-		branch="$${remote#origin/}"; \
-		git fetch -q origin "+refs/heads/$$branch:refs/heads/$$branch"; \
-		git checkout -q "$$branch" -- ':(exclude)ui' . ; \
+	git fetch --all --prune
+	# The branch list comes from the remote so it is current even on the first
+	# build after a new release branch appears (the cached remote-tracking refs
+	# lag behind). Auto-gc is disabled inside the loop: a background gc can
+	# race the ref updates and silently leave a stale local branch behind,
+	# which only surfaces much later as a missing-object error from antora.
+	# Failures abort the build immediately instead.
+	set -e; for branch in $$(git ls-remote --heads origin | sed 's|.*refs/heads/||' | grep -E 'release[/-]'); do \
+		git -c gc.auto=0 fetch origin "+refs/heads/$$branch:refs/heads/$$branch"; \
+		git -c gc.auto=0 checkout -q "$$branch" -- . ; \
 	done
 	# restore the working tree of the current commit and drop files that
 	# only exist on other branches (ignored files like node_modules stay)


### PR DESCRIPTION
## Description

Production docs builds fail with `FATAL (antora): Could not find e9b0f5de... (branch: release-26.7)`.

### Root cause

e9b0f5de is not a commit, it is a blob: `ui/NOTICE` on release-26.7.
And it could not be found because (see the fix section below) we excluded `ui` from checkout because it used to be a submodule. And the [`isomorphic-git`](https://isomorphic-git.org/) used by Antora can't dynamically fetch missing content so.... it was missing.

### The fix

```
-             git -c gc.auto=0 checkout -q "$$branch" -- ':(exclude)ui' . ; \
+             git -c gc.auto=0 checkout -q "$$branch" -- . ; \
```

Do not exclude UI anymore... simple as that :(

### Separate preemptive fixes/hardening

These were "discovered" during the research...would not really help the root cause but good to have anyway.

- `gc.auto=0` for the loop commands, so background gc cannot race the ref updates.
- `set -e` + no `-q` on fetch: to just fail where the failure actually happens to get a better error message
- `git fetch --all --prune` to delete stale stuff from the cache, not only add or update

The first build after a new release branch can also fail because the branch list that is used uses the last cached git state from the previous run. That doesn't have the new release branch so it can fail. This now uses `git ls-remote --heads origin` (instead of `git branch -r`) to make sure we have the up-to-date state.

**Verified** by simulation (by Claude): blobless clone (like netlify's), stale `release-26.7` ref planted pointing at an outdated commit, `make netlify-fetch` run - the ref force-updates to the real remote tip, all content blobs of every release tip are present (only the deliberately excluded `ui/` blobs stay missing, which antora never reads), working tree clean, exit 0.

