### PR TITLE
fix: display icons on local builds

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -327,7 +327,7 @@ asciidoc:
   attributes:
     base-repo: https://github.com/stackabletech
     # an external icon. Create a link opening in a new tab like this: http://my-url.com[Text {external-link-icon}^]
-    external-link-icon: "<svg class=\"svg-icon\" style=\"width: 0.75em; height: 0.75em; margin-left: 3px;\" aria-hidden=\"true\"><use href=\"/_/img/icons.svg#icon-external-link\"/></svg>"
+    external-link-icon: "<svg class=\"svg-icon\" style=\"width: 0.75em; height: 0.75em; margin-left: 3px;\" aria-hidden=\"true\"><use href=\"#icon-external-link\"/></svg>"
 # the default caching directory is ./.cache/antora
 # Antora caches the git repos, this can sometimes lead to stale content
 # use 'make clean' to remove the build and cache directory

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -312,7 +312,7 @@ asciidoc:
   attributes:
     base-repo: https://github.com/stackabletech
     # an external icon. Create a link opening in a new tab like this: http://my-url.com[Text {external-link-icon}^]
-    external-link-icon: "<svg class=\"svg-icon\" style=\"width: 0.75em; height: 0.75em; margin-left: 3px;\" aria-hidden=\"true\"><use href=\"/_/img/icons.svg#icon-external-link\"/></svg>"
+    external-link-icon: "<svg class=\"svg-icon\" style=\"width: 0.75em; height: 0.75em; margin-left: 3px;\" aria-hidden=\"true\"><use href=\"#icon-external-link\"/></svg>"
 # the default caching directory is ./.cache/antora
 # Antora caches the git repos, this can sometimes lead to stale content
 # use 'make clean' to remove the build and cache directory

--- a/modules/reference/pages/glossary.adoc
+++ b/modules/reference/pages/glossary.adoc
@@ -1,5 +1,5 @@
 = Glossary
-:li: pass:[<svg class="svg-icon" style="width: 0.875em; height: 0.875em; margin-left: 5px;" aria-hidden="true"><use href="/_/img/icons.svg#icon-link"/></svg>]
+:li: pass:[<svg class="svg-icon" style="width: 0.875em; height: 0.875em; margin-left: 5px;" aria-hidden="true"><use href="#icon-link"/></svg>]
 :description: Glossary of Stackable terms, including Role, Role Group, and Stacklet, with definitions and links to detailed explanations.
 
 // refined styling for the glossary

--- a/only-dev-antora-playbook.yml
+++ b/only-dev-antora-playbook.yml
@@ -105,7 +105,7 @@ asciidoc:
   attributes:
     base-repo: https://github.com/stackabletech
     # an external icon. Create a link opening in a new tab like this: http://my-url.com[Text {external-link-icon}^]
-    external-link-icon: "<svg class=\"svg-icon\" style=\"width: 0.75em; height: 0.75em; margin-left: 3px;\" aria-hidden=\"true\"><use href=\"/_/img/icons.svg#icon-external-link\"/></svg>"
+    external-link-icon: "<svg class=\"svg-icon\" style=\"width: 0.75em; height: 0.75em; margin-left: 3px;\" aria-hidden=\"true\"><use href=\"#icon-external-link\"/></svg>"
 # the default caching directory is ./.cache/antora
 # Antora caches the git repos, this can sometimes lead to stale content
 # use 'make clean' to remove the build and cache directory

--- a/supplemental-ui/partials/navbar.hbs
+++ b/supplemental-ui/partials/navbar.hbs
@@ -18,7 +18,7 @@
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "reference/index.html") }}}">CRD Reference</a>
         {{else}}
         <a class="navbar-item" href="{{{ page.attributes.crd-docs }}}" target="_blank">
-            CRD Reference <svg class="svg-icon" style="width: 0.875em; height: 0.875em; margin-left: 5px;" aria-hidden="true"><use href="{{{uiRootPath}}}/img/icons.svg#icon-external-link"/></svg>
+            CRD Reference <svg class="svg-icon" style="width: 0.875em; height: 0.875em; margin-left: 5px;" aria-hidden="true"><use href="#icon-external-link"/></svg>
         </a>
         {{/if}}
         <hr class="navbar-divider">
@@ -95,13 +95,13 @@
     <a class="navbar-link" href="#">Community</a>
     <div class="navbar-dropdown">
         <a class="navbar-item" href="https://stackable.tech/en/" target="_blank">
-            Homepage <svg class="svg-icon" style="width: 0.875em; height: 0.875em; margin-left: 5px;" aria-hidden="true"><use href="{{{uiRootPath}}}/img/icons.svg#icon-external-link"/></svg>
+            Homepage <svg class="svg-icon" style="width: 0.875em; height: 0.875em; margin-left: 5px;" aria-hidden="true"><use href="#icon-external-link"/></svg>
         </a>
         <a class="navbar-item" href="https://github.com/stackabletech/" target="_blank">
-            GitHub <svg class="svg-icon" style="width: 0.875em; height: 0.875em; margin-left: 5px;" aria-hidden="true"><use href="{{{uiRootPath}}}/img/icons.svg#icon-external-link"/></svg>
+            GitHub <svg class="svg-icon" style="width: 0.875em; height: 0.875em; margin-left: 5px;" aria-hidden="true"><use href="#icon-external-link"/></svg>
         </a>
         <a class="navbar-item" href="https://discord.com/invite/7kZ3BNnCAF" target="_blank">
-            Discord <svg class="svg-icon" style="width: 0.875em; height: 0.875em; margin-left: 5px;" aria-hidden="true"><use href="{{{uiRootPath}}}/img/icons.svg#icon-external-link"/></svg>
+            Discord <svg class="svg-icon" style="width: 0.875em; height: 0.875em; margin-left: 5px;" aria-hidden="true"><use href="#icon-external-link"/></svg>
         </a>
         <hr class="navbar-divider">
         <a class="navbar-item" href="{{{ relativize (versioned "home" page "contributor/index.html") }}}">Contributing</a>

--- a/truly-local-playbook.yml
+++ b/truly-local-playbook.yml
@@ -70,7 +70,7 @@ asciidoc:
   attributes:
     base-repo: https://github.com/stackabletech
     # an external icon. Create a link opening in a new tab like this: http://my-url.com[Text {external-link-icon}^]
-    external-link-icon: "<svg class=\"svg-icon\" style=\"width: 0.75em; height: 0.75em; margin-left: 3px;\" aria-hidden=\"true\"><use href=\"/_/img/icons.svg#icon-external-link\"/></svg>"
+    external-link-icon: "<svg class=\"svg-icon\" style=\"width: 0.75em; height: 0.75em; margin-left: 3px;\" aria-hidden=\"true\"><use href=\"#icon-external-link\"/></svg>"
 # the default caching directory is ./.cache/antora
 # Antora caches the git repos, this can sometimes lead to stale content
 # use 'make clean' to remove the build and cache directory

--- a/ui/src/layouts/404.hbs
+++ b/ui/src/layouts/404.hbs
@@ -4,6 +4,7 @@
 {{> head defaultPageTitle='Page Not Found'}}
   </head>
   <body class="status-404">
+{{> icons}}
 {{> universal-nav}}
 {{> header}}
 {{> body}}

--- a/ui/src/layouts/default.hbs
+++ b/ui/src/layouts/default.hbs
@@ -4,6 +4,7 @@
 {{> head defaultPageTitle='Untitled'}}
   </head>
   <body class="article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
+{{> icons}}
 {{> universal-nav}}
 {{> header}}
 {{> body}}

--- a/ui/src/layouts/landing.hbs
+++ b/ui/src/layouts/landing.hbs
@@ -4,6 +4,7 @@
 {{> head defaultPageTitle='Untitled'}}
   </head>
   <body class="article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
+{{> icons}}
 {{> universal-nav}}
 {{> header}}
     <div class="body">

--- a/ui/src/partials/footer-content.hbs
+++ b/ui/src/partials/footer-content.hbs
@@ -55,16 +55,16 @@
         <div>© 2025 Stackable.</div>
         <div class="social-icons-container">
           <a class="social-icon" href="https://www.xing.com/pages/stackable" target="_blank">
-            <svg class="svg-icon" aria-hidden="true"><use href="{{{uiRootPath}}}/img/icons.svg#icon-xing"/></svg>
+            <svg class="svg-icon" aria-hidden="true"><use href="#icon-xing"/></svg>
           </a>
           <a class="social-icon" href="https://www.linkedin.com/company/stackabletech/" target="_blank">
-            <svg class="svg-icon" aria-hidden="true"><use href="{{{uiRootPath}}}/img/icons.svg#icon-linkedin"/></svg>
+            <svg class="svg-icon" aria-hidden="true"><use href="#icon-linkedin"/></svg>
           </a>
           <a class="social-icon" href="https://github.com/stackabletech" target="_blank">
-            <svg class="svg-icon" aria-hidden="true"><use href="{{{uiRootPath}}}/img/icons.svg#icon-github"/></svg>
+            <svg class="svg-icon" aria-hidden="true"><use href="#icon-github"/></svg>
           </a>
           <a class="social-icon" href="https://twitter.com/stackabletech" target="_blank">
-            <svg class="svg-icon" aria-hidden="true"><use href="{{{uiRootPath}}}/img/icons.svg#icon-twitter"/></svg>
+            <svg class="svg-icon" aria-hidden="true"><use href="#icon-twitter"/></svg>
           </a>
         </div>
       </div>

--- a/ui/src/partials/header.hbs
+++ b/ui/src/partials/header.hbs
@@ -33,7 +33,7 @@
         <span></span>
       </button>
       <div id="search-button" class="navbar-item">
-        <svg class="svg-icon" aria-hidden="true"><use href="{{{uiRootPath}}}/img/icons.svg#icon-search"/></svg>
+        <svg class="svg-icon" aria-hidden="true"><use href="#icon-search"/></svg>
         <div id="search-background"></div>
         <div id="search">
           <div id="search-input"></div>

--- a/ui/src/partials/icons.hbs
+++ b/ui/src/partials/icons.hbs
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;" aria-hidden="true">
   <!--
     Icon path data from Font Awesome Free 6.2.1 (https://fontawesome.com),
     licensed under CC BY 4.0 (https://fontawesome.com/license/free).


### PR DESCRIPTION
The following description is provided by Claude:

## Problem

  Icons were invisible in local builds. Opening a generated page directly from disk showed no
  search icon, no footer social icons and no "external link" arrows next to outbound links.

  Separately, the link icons on the glossary page are missing on the live site for all released
  versions (e.g. /home/stable/reference/glossary/), while nightly is fine.

  ## Cause

  Both problems trace back to #890, which replaced the icon font with SVG icons.

  The icons now live in a single shared file that each page points at. That pointer is a request
  for a second file, and browsers refuse those on pages opened from disk — so in local builds
  every icon silently disappeared. Served over HTTP it works, which is why the live site looked
  fine and this slipped through review.

  The glossary is a different case. Its icon is defined in the page source itself, which is
  versioned, so released branches still contain the old icon-font markup. The stylesheet that
  made it visible was removed in #890, so those icons now render as nothing.

  ## Approach

  The icon definitions are now included directly in every page, and icons refer to them within
  the same page. Nothing needs to be fetched, so they work identically whether the site is opened
  from disk, served locally, or deployed.

  This adds roughly 2.7 kB (compressed) per page. The far larger saving from #890 — dropping
  Font Awesome and its web fonts — is unaffected.

  ## Not covered here

  The glossary icons remain broken in already-released versions, since the fix is in page source
  that those branches don't have. -> This would need separate PRs backporting the change