### PR TITLE
perf: Give the navbar and footer logos explicit dimensions

### DIFF
--- a/ui/src/css/header.css
+++ b/ui/src/css/header.css
@@ -43,11 +43,23 @@ body {
   word-wrap: normal;
 }
 
+/* The img carries width/height attributes so its space is reserved before it
+ * loads. Two consequences to keep in mind when touching this rule:
+ *
+ * width: auto is required, not redundant. Those attributes are presentational
+ * hints that set a real width, so without it the logo renders at its full 199px
+ * against a 22px height and stretches by a third. Setting it hands sizing back
+ * to the aspect ratio the attributes imply.
+ *
+ * The gap is a margin, not padding, because aspect-ratio sizes the box named by
+ * box-sizing -- border-box here -- so padding would count inside the ratio and
+ * squash the image by exactly that much. */
 .navbar-brand .navbar-item:first-child img {
   height: 22px;
+  width: auto;
   display: inline-block;
   margin-top: -4px;
-  padding-right: 20px;
+  margin-right: 20px;
 }
 
 .navbar-brand .navbar-item.documentation-link {

--- a/ui/src/partials/footer-content.hbs
+++ b/ui/src/partials/footer-content.hbs
@@ -4,7 +4,7 @@
       <!-- link columns -->
       <div class="footer-info">
         <div class="footer-info-item-large">
-          <img src="{{{uiRootPath}}}/img/logo-2-1.png">
+          <img src="{{{uiRootPath}}}/img/logo-2-1.png" width="150" height="26">
           <p class="footer-motto">
             your data, your platform
           </p>

--- a/ui/src/partials/header.hbs
+++ b/ui/src/partials/header.hbs
@@ -2,7 +2,7 @@
   <nav class="navbar">
     <div id="topbar-left" class="navbar-brand">
       <a class="navbar-item" href="{{{ relativize (versioned "home" page "index.html") }}}">
-        <img src="{{{uiRootPath}}}/img/stackable-logo.png">
+        <img src="{{{uiRootPath}}}/img/stackable-logo.png" width="199" height="30">
       </a>
       <a class="navbar-item documentation-link" href="{{{ relativize (versioned "home" page "index.html") }}}">
         Docs


### PR DESCRIPTION
If you include images but they are not loaded yet the browser doesn't know how much "space" to reserve for them. So they do whatever until the picture is there and then they have to "reflow" when the image arrives.

One way around this is to give images an explicit size in HTML so the browsers know how much space to reserve. This PR does that for two occasions. This was again flagged by Lighthouse.