### PR TITLE
chore: Sync the vendored UI with upstream antora-ui-default, part 3: CSS stuff

### DIFF
--- a/ui/UPSTREAM
+++ b/ui/UPSTREAM
@@ -11,6 +11,12 @@
 # Update the SHA (and this file) whenever upstream changes have been
 # reviewed and ported.
 #
-# Last reviewed: NOT YET RECORDED - the fork predates this marker.
-# Planned: the phase 3 upstream re-sync establishes the first SHA
-# (see ~/dev/stackable/plans/documentation-overhaul.md).
+# Reviewed against: 0e38223a (2026-07-16)
+#
+# Not every upstream commit in that range is present. Some were skipped
+# because the subsystem diverged: the search UI is a custom Pagefind
+# integration, the typefaces come from fontsource, tabs ship from
+# @asciidoctor/tabs, and the highlight.js language set is our own. Others
+# were already present from earlier cherry-picks. `git log -- ui/` carries
+# the upstream authorship and message of each ported commit, so a future
+# re-sync can tell what landed from what did not.

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -698,7 +698,7 @@
 .doc .literalblock .title,
 .doc .listingblock .title,
 .doc .openblock .title,
-.doc .tableblock caption {
+.doc table.tableblock caption {
   color: var(--caption-font-color);
   font-size: calc(16 / var(--rem-base) * 1rem);
   font-style: var(--caption-font-style);
@@ -708,7 +708,7 @@
   padding-bottom: 0.075rem;
 }
 
-.doc .tableblock caption {
+.doc table.tableblock caption {
   text-align: left;
 }
 
@@ -820,7 +820,7 @@
 }
 
 /* NEEDS REVIEW prevent pre in table from causing article to exceed bounds */
-.doc .tableblock pre,
+.doc table.tableblock pre,
 .doc .listingblock.wrap pre {
   white-space: pre-wrap;
 }

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -267,7 +267,6 @@
 .doc .literalblock,
 .doc .sidebarblock,
 .doc .verseblock,
-.doc .videoblock,
 .doc .quoteblock,
 .doc .partintro,
 .doc details,

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -275,17 +275,15 @@
   margin: 1rem 0 0;
 }
 
-.doc table.tableblock {
-  font-size: calc(15 / var(--rem-base) * 1rem);
-}
-
 .doc table.tableblock,
 .doc table.tableblock + * {
   margin-top: 1.5rem;
 }
 
-.doc table.tableblock pre {
-  font-size: inherit;
+.doc table.tableblock,
+.doc table.tableblock pre,
+.doc .admonitionblock pre {
+  font-size: calc(15 / var(--rem-base) * 1rem);
 }
 
 .doc p.tableblock + p.tableblock {
@@ -406,10 +404,6 @@
 .doc .admonitionblock td.content > :not(.title):first-child,
 .doc .admonitionblock td.content > .title + * {
   margin-top: 0;
-}
-
-.doc .admonitionblock pre {
-  font-size: calc(15 / var(--rem-base) * 1rem);
 }
 
 .doc .admonitionblock > table {

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -705,8 +705,8 @@
   text-align: left;
 }
 
-.doc .ulist .title,
-.doc .olist .title {
+.doc .olist .title,
+.doc .ulist .title {
   font-style: var(--caption-font-style);
   font-weight: var(--caption-font-weight);
   margin-bottom: 0.25rem;

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -518,7 +518,8 @@
   margin-top: -0.2em;
 }
 
-.doc .videoblock iframe {
+.doc .videoblock iframe,
+.doc .videoblock video {
   max-width: 100%;
   vertical-align: middle;
 }
@@ -712,8 +713,8 @@
   margin-bottom: 0.25rem;
 }
 
-.doc .videoblock .title,
-.doc .imageblock .title {
+.doc .imageblock .title,
+.doc .videoblock .title {
   margin-top: 0.5rem;
   padding-bottom: 0;
 }

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -280,14 +280,16 @@
   margin-top: 1.5rem;
 }
 
-.doc table.tableblock,
-.doc table.tableblock pre,
-.doc .admonitionblock pre {
+.doc table.tableblock {
   font-size: calc(15 / var(--rem-base) * 1rem);
 }
 
 .doc p.tableblock + p.tableblock {
   margin-top: 0.5rem;
+}
+
+.doc table.tableblock pre {
+  font-size: inherit;
 }
 
 .doc td.tableblock > .content {
@@ -404,6 +406,10 @@
 .doc .admonitionblock td.content > :not(.title):first-child,
 .doc .admonitionblock td.content > .title + * {
   margin-top: 0;
+}
+
+.doc .admonitionblock td.content pre {
+  font-size: calc(15 / var(--rem-base) * 1rem);
 }
 
 .doc .admonitionblock > table {

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -261,6 +261,7 @@
 .doc .olist,
 .doc .ulist,
 .doc .exampleblock,
+.doc .videoblock,
 .doc .imageblock,
 .doc .listingblock,
 .doc .literalblock,
@@ -691,11 +692,11 @@
 
 .doc .admonitionblock .title,
 .doc .exampleblock .title,
+.doc .videoblock .title,
 .doc .imageblock .title,
 .doc .literalblock .title,
 .doc .listingblock .title,
 .doc .openblock .title,
-.doc .videoblock .title,
 .doc .tableblock caption {
   color: var(--caption-font-color);
   font-size: calc(16 / var(--rem-base) * 1rem);
@@ -707,6 +708,7 @@
   text-align: left;
 }
 
+.doc .videoblock .title,
 .doc .imageblock .title {
   margin-top: 0.5rem;
   padding-bottom: 0;

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -700,12 +700,22 @@
 .doc .tableblock caption {
   color: var(--caption-font-color);
   font-size: calc(16 / var(--rem-base) * 1rem);
+  font-style: var(--caption-font-style);
   font-weight: var(--caption-font-weight);
-  font-style: italic;
   hyphens: none;
   letter-spacing: 0.01em;
   padding-bottom: 0.075rem;
+}
+
+.doc .tableblock caption {
   text-align: left;
+}
+
+.doc .ulist .title,
+.doc .olist .title {
+  font-style: var(--caption-font-style);
+  font-weight: var(--caption-font-weight);
+  margin-bottom: 0.25rem;
 }
 
 .doc .videoblock .title,

--- a/ui/src/css/header.css
+++ b/ui/src/css/header.css
@@ -36,6 +36,10 @@ body {
   display: flex;
 }
 
+.navbar-brand .navbar-item {
+  color: var(--navbar-font-color);
+}
+
 .navbar-brand .navbar-item:first-child {
   padding: 0;
 }

--- a/ui/src/css/main.css
+++ b/ui/src/css/main.css
@@ -1,3 +1,7 @@
+body.-toc aside.toc.sidebar {
+  display: none;
+}
+
 main {
   min-width: 0; /* min-width: 0 required for flexbox to constrain overflowing elements */
 }

--- a/ui/src/css/nav.css
+++ b/ui/src/css/nav.css
@@ -83,6 +83,10 @@
   height: 100%;
 }
 
+.nav-panel-menu:only-child {
+  height: 100%;
+}
+
 .nav-panel-menu:not(.is-active) .nav-menu {
   opacity: 0.75;
 }

--- a/ui/src/css/vars.css
+++ b/ui/src/css/vars.css
@@ -96,6 +96,7 @@
   --admonition-background: var(--panel-background);
   --admonition-label-font-weight: var(--body-font-weight-bold);
   --caption-font-color: var(--color-text);
+  --caption-font-style: italic;
   --caption-font-weight: var(--body-font-weight-bold);
   --code-background: var(--panel-background);
   --code-font-color: var(--body-font-color);


### PR DESCRIPTION
See these two previous ones for details on the "why":

* https://github.com/stackabletech/documentation/pull/906
* https://github.com/stackabletech/documentation/pull/920

> [!NOTE]
> Similar to last time: I want a review, but the merge has to be a force merge due to the CLA stuff. This is explained in an earlier PR and is part of the readme or some other file

There is only one user visible change I could find and it's tiny and ...consistent.

New:
<img width="659" height="256" alt="image" src="https://github.com/user-attachments/assets/35b15564-4f8d-4390-ab27-4d74caaaadf1" />

Old:
<img width="616" height="207" alt="image" src="https://github.com/user-attachments/assets/75cf9879-f1a5-48f0-94ad-d2cfe3560934" />


The .title on a bulleted or numbered list is now italic.
