### PR TITLE
fix: Lifecycle Policies menu entry not correct

### DIFF
--- a/modules/compliance/nav.adoc
+++ b/modules/compliance/nav.adoc
@@ -1,6 +1,6 @@
 * xref:index.adoc[Compliance]
 ** xref:product-information.adoc[]
-** xref:policies.adoc[]
+** xref:policies.adoc[Lifecycle Policies]
 ** xref:licenses.adoc[Licenses]
 ** xref:export.adoc[Export Control]
 ** xref:cra.adoc[Cyber Resilience Act]


### PR DESCRIPTION
The entry for the page "Lifecycle policies" in the top menu was "Policies", which doesn't reflect the actual content.