### PR TITLE
fix: Make keyboard focus visible and name the unnamed controls

### DIFF
--- a/ui/build.mjs
+++ b/ui/build.mjs
@@ -158,10 +158,8 @@ const faVersion = JSON.parse(readFileSync(resolve(faDir, 'package.json'), 'utf8'
 const icons = {
   'external-link': 'solid/arrow-up-right-from-square',
   search: 'solid/magnifying-glass',
-  xing: 'brands/xing',
   linkedin: 'brands/linkedin',
   github: 'brands/github',
-  twitter: 'brands/twitter',
   link: 'solid/link'
 };
 const symbols = Object.entries(icons).map(([name, faIcon]) => {

--- a/ui/src/css/base.css
+++ b/ui/src/css/base.css
@@ -88,7 +88,11 @@ button::-moz-focus-inner {
 summary {
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
-  outline: none;
+}
+
+summary:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
 }
 
 table {

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -132,12 +132,20 @@
   content: "\00a7";
 }
 
+/* A focusable control that only appears on hover is invisible to anyone
+ * tabbing to it, so every reveal below pairs hover with focus. */
 .doc h1:hover .anchor,
 .doc h2:hover .anchor,
 .doc h3:hover .anchor,
 .doc h4:hover .anchor,
 .doc h5:hover .anchor,
-.doc h6:hover .anchor {
+.doc h6:hover .anchor,
+.doc h1 .anchor:focus-visible,
+.doc h2 .anchor:focus-visible,
+.doc h3 .anchor:focus-visible,
+.doc h4 .anchor:focus-visible,
+.doc h5 .anchor:focus-visible,
+.doc h6 .anchor:focus-visible {
   visibility: visible;
 }
 
@@ -853,7 +861,8 @@
   z-index: 1;
 }
 
-.doc .listingblock:hover .source-toolbox {
+.doc .listingblock:hover .source-toolbox,
+.doc .listingblock:focus-within .source-toolbox {
   visibility: visible;
 }
 

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -875,12 +875,16 @@
   background: none;
   border: none;
   color: inherit;
-  outline: none;
   padding: 0;
   font-size: inherit;
   line-height: inherit;
   width: 1em;
   height: 1em;
+}
+
+.doc .source-toolbox .copy-button:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
 }
 
 .doc .source-toolbox .copy-icon {

--- a/ui/src/css/header.css
+++ b/ui/src/css/header.css
@@ -193,8 +193,13 @@ body {
   color: var(--navbar-menu-font-color-hover);
 }
 
+/* font: inherit is required, not tidiness: .svg-icon sizes the magnifier in em,
+ * so the UA button font would shrink it from 16px to 13px. */
 #search-button {
+  background: none;
+  border: none;
   cursor: pointer;
+  font: inherit;
   padding-right: 2rem;
 }
 
@@ -205,7 +210,6 @@ body {
 .navbar-burger {
   background: none;
   border: none;
-  outline: none;
   line-height: 1;
   position: relative;
   padding: 0;
@@ -215,6 +219,11 @@ body {
   align-items: center;
   justify-content: center;
   min-width: 0;
+}
+
+.navbar-burger:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
 }
 
 .navbar-burger span {

--- a/ui/src/css/header.css
+++ b/ui/src/css/header.css
@@ -193,7 +193,7 @@ body {
   color: var(--navbar-menu-font-color-hover);
 }
 
-/* font: inherit is required, not tidiness: .svg-icon sizes the magnifier in em,
+/* font: inherit is required: .svg-icon sizes the magnifier in em,
  * so the UA button font would shrink it from 16px to 13px. */
 #search-button {
   background: none;

--- a/ui/src/css/nav.css
+++ b/ui/src/css/nav.css
@@ -121,12 +121,16 @@
   height: 1em;
   margin-right: -0.5rem;
   opacity: 0.75;
-  outline: none;
   padding: 0;
   position: sticky;
   top: calc((var(--nav-line-height) - 1 + 0.5) * 1rem);
   visibility: hidden;
   width: 1em;
+}
+
+.nav-menu-toggle:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
 }
 
 .nav-menu-toggle.is-active {
@@ -177,7 +181,6 @@
 .nav-item-toggle {
   background: transparent url(../img/caret.svg) no-repeat center / 50%;
   border: none;
-  outline: none;
   line-height: inherit;
   padding: 0;
   position: absolute;
@@ -185,6 +188,11 @@
   width: calc(var(--nav-line-height) * 1em);
   margin-top: -0.05em;
   margin-left: calc(var(--nav-line-height) * -1em);
+}
+
+.nav-item-toggle:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
 }
 
 .nav-item.is-active > .nav-item-toggle {

--- a/ui/src/css/nav.css
+++ b/ui/src/css/nav.css
@@ -137,7 +137,8 @@
   background-image: url(../img/octicons-16.svg#view-fold);
 }
 
-.nav-panel-menu.is-active:hover .nav-menu-toggle {
+.nav-panel-menu.is-active:hover .nav-menu-toggle,
+.nav-panel-menu.is-active:focus-within .nav-menu-toggle {
   visibility: visible;
 }
 

--- a/ui/src/css/tabs.css
+++ b/ui/src/css/tabs.css
@@ -2,3 +2,10 @@
 .tabs {
   margin-top: 1rem;
 }
+
+/* asciidoctor-tabs sets `outline: none` on its tab list items, so keyboard users
+ * cannot see which tab they are on. Imported before this file, so this wins. */
+.tablist > ul li:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
+}

--- a/ui/src/css/toc.css
+++ b/ui/src/css/toc.css
@@ -76,7 +76,11 @@
 
 .sidebar.toc .toc-menu a {
   display: block;
-  outline: none;
+}
+
+.sidebar.toc .toc-menu a:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
 }
 
 .toc .toc-menu a:hover {

--- a/ui/src/css/toolbar.css
+++ b/ui/src/css/toolbar.css
@@ -30,12 +30,16 @@
   background: url(../img/menu.svg) no-repeat 50% 47.5%;
   background-size: 49%;
   border: none;
-  outline: none;
   line-height: inherit;
   padding: 0;
   height: var(--toolbar-height);
   width: var(--toolbar-height);
   margin-right: -0.25rem;
+}
+
+.nav-toggle:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
 }
 
 @media screen and (min-width: 1024px) {

--- a/ui/src/js/08-search.js
+++ b/ui/src/js/08-search.js
@@ -4,6 +4,7 @@
   function openSearchPopover () {
     document.getElementById('search-background').style.display = 'block'
     document.getElementById('search').style.display = 'block'
+    setSearchExpanded(true)
 
     // the search assets load on first use (see footer-scripts.hbs)
     window.loadSearch().then(function () {
@@ -17,6 +18,12 @@
   function closeSearchPopover () {
     document.getElementById('search-background').style.display = 'none'
     document.getElementById('search').style.display = 'none'
+    setSearchExpanded(false)
+  }
+
+  function setSearchExpanded (expanded) {
+    var button = document.getElementById('search-button')
+    if (button) button.setAttribute('aria-expanded', String(expanded))
   }
 
   function focusSearchInput () {

--- a/ui/src/js/09-heading-anchors.js
+++ b/ui/src/js/09-heading-anchors.js
@@ -1,0 +1,15 @@
+;(function () {
+  'use strict'
+
+  // Asciidoctor emits section anchors as an empty <a class="anchor"> inside the
+  // heading, so they are links with no accessible name.
+  // The glyph comes from CSS, so there is no text to find: name them after the heading they link to.
+  var anchors = document.querySelectorAll('.doc a.anchor')
+  Array.prototype.forEach.call(anchors, function (anchor) {
+    if (anchor.getAttribute('aria-label')) return
+    var heading = anchor.parentNode
+    if (!heading) return
+    var text = heading.textContent.trim()
+    if (text) anchor.setAttribute('aria-label', 'Link to ' + text)
+  })
+})()

--- a/ui/src/partials/footer-content.hbs
+++ b/ui/src/partials/footer-content.hbs
@@ -4,7 +4,7 @@
       <!-- link columns -->
       <div class="footer-info">
         <div class="footer-info-item-large">
-          <img src="{{{uiRootPath}}}/img/logo-2-1.png" width="150" height="26">
+          <img src="{{{uiRootPath}}}/img/logo-2-1.png" width="150" height="26" alt="Stackable">
           <p class="footer-motto">
             your data, your platform
           </p>
@@ -57,17 +57,11 @@
       <div class="c-and-socials">
         <div>© 2025 Stackable.</div>
         <div class="social-icons-container">
-          <a class="social-icon" href="https://www.xing.com/pages/stackable" target="_blank">
-            <svg class="svg-icon" aria-hidden="true"><use href="#icon-xing"/></svg>
-          </a>
-          <a class="social-icon" href="https://www.linkedin.com/company/stackabletech/" target="_blank">
+          <a class="social-icon" href="https://www.linkedin.com/company/stackabletech/" target="_blank" aria-label="Stackable on LinkedIn">
             <svg class="svg-icon" aria-hidden="true"><use href="#icon-linkedin"/></svg>
           </a>
-          <a class="social-icon" href="https://github.com/stackabletech" target="_blank">
+          <a class="social-icon" href="https://github.com/stackabletech" target="_blank" aria-label="Stackable on GitHub">
             <svg class="svg-icon" aria-hidden="true"><use href="#icon-github"/></svg>
-          </a>
-          <a class="social-icon" href="https://twitter.com/stackabletech" target="_blank">
-            <svg class="svg-icon" aria-hidden="true"><use href="#icon-twitter"/></svg>
           </a>
         </div>
       </div>

--- a/ui/src/partials/header.hbs
+++ b/ui/src/partials/header.hbs
@@ -2,7 +2,7 @@
   <nav class="navbar">
     <div id="topbar-left" class="navbar-brand">
       <a class="navbar-item" href="{{{ relativize (versioned "home" page "index.html") }}}">
-        <img src="{{{uiRootPath}}}/img/stackable-logo.png" width="199" height="30">
+        <img src="{{{uiRootPath}}}/img/stackable-logo.png" width="199" height="30" alt="Stackable">
       </a>
       <a class="navbar-item documentation-link" href="{{{ relativize (versioned "home" page "index.html") }}}">
         Docs
@@ -32,13 +32,13 @@
         <span></span>
         <span></span>
       </button>
-      <div id="search-button" class="navbar-item">
+      <button type="button" id="search-button" class="navbar-item" aria-label="Search" aria-expanded="false" aria-controls="search">
         <svg class="svg-icon" aria-hidden="true"><use href="#icon-search"/></svg>
-        <div id="search-background"></div>
-        <div id="search">
-          <div id="search-input"></div>
-          <ul id="search-results"></ul>
-        </div>
+      </button>
+      <div id="search-background"></div>
+      <div id="search" role="dialog" aria-label="Search">
+        <div id="search-input"></div>
+        <ul id="search-results"></ul>
       </div>
       {{#if @root.page.versions}}
       {{#with @root.page.versions}}

--- a/ui/src/partials/toolbar.hbs
+++ b/ui/src/partials/toolbar.hbs
@@ -1,7 +1,7 @@
 <div class="toolbar" role="navigation">
 {{> nav-toggle}}
   {{#with site.homeUrl}}
-  <a href="{{{relativize this}}}" class="home-link{{#if @root.page.home}} is-current{{/if}}"></a>
+  <a href="{{{relativize this}}}" class="home-link{{#if @root.page.home}} is-current{{/if}}" aria-label="Home"></a>
   {{/with}}
 {{> breadcrumbs}}
 {{> edit-this-page}}


### PR DESCRIPTION
This continues my journey to improve our PageSpeed score.
We are not "great" on accessibility yet and this tries to fix some of that. It goes from 83 to 93 for me with this PR and more will come.

New:
Homepage
<img width="967" height="171" alt="image" src="https://github.com/user-attachments/assets/13a6221c-01d8-4cc4-8462-d6d75b8b3e67" />

Operator
<img width="726" height="138" alt="image" src="https://github.com/user-attachments/assets/08caef40-bb43-4fea-8ffc-5a8ae3f85989" />


Old:
Homepage
<img width="947" height="146" alt="image" src="https://github.com/user-attachments/assets/3906ba63-7bba-4a87-8dc2-a93e09bbf127" />

Operator
<img width="716" height="133" alt="image" src="https://github.com/user-attachments/assets/148511c7-b166-4fc4-b4c8-ae84fdc7c819" />



There should be _no_ user visible changes - I clicked around and it all looked good. But keyboard focus works much better. The menu bar for example can now be tabbed through and you can reach the search thing.
In the sidebar menu it is now also possible to tab through everything. Some items also didn't have a visible "ring" on it when selected via keyboard. That is all fixed. And some icons etc. now have alt names.

There will be more to come.