### PR TITLE
docs: add vulnerability disclosure to footer, analogue to website

### DIFF
--- a/ui/src/partials/footer-content.hbs
+++ b/ui/src/partials/footer-content.hbs
@@ -35,6 +35,9 @@
             <li>
               <a href="https://stackable.tech/en/data-protection">Data Protection</a>
             </li>
+            <li>
+              <a href="https://stackable.tech/en/vulnerability-disclosure-policy">Vulnerability Disclosure</a>
+            </li>
           </ul>
         </div>
         <div class="footer-info-item">


### PR DESCRIPTION
The Stackable website shows a link to our Vulnerability Disclosure Policy in its footer that is missing in our docs.