### PR TITLE
fix: Lifecycle Policies menu entry not correct (now in header menu)

### DIFF
--- a/supplemental-ui/partials/navbar.hbs
+++ b/supplemental-ui/partials/navbar.hbs
@@ -82,9 +82,9 @@
             (eq page.version "25.3")
             (eq page.version "25.7")
         )}}
-        <a class="navbar-item" href="{{{ relativize (versioned "home" page "policies.html") }}}">Policies</a>
+        <a class="navbar-item" href="{{{ relativize (versioned "home" page "policies.html") }}}">Lifecycle Policies</a>
         {{else}}
-        <a class="navbar-item" href="{{{ relativize (versioned "home" page "compliance/policies.html") }}}">Policies</a>
+        <a class="navbar-item" href="{{{ relativize (versioned "home" page "compliance/policies.html") }}}">Lifecycle Policies</a>
         {{/if}}
         <a class="navbar-item" href="{{{ relativize "/home/stable/compliance/licenses" }}}">Licenses</a>
         <a class="navbar-item" href="{{{ relativize "/home/stable/compliance/export" }}}">Export Control</a>


### PR DESCRIPTION
Not sure what the file edited in #928 is for, but the header menu will get the proper title for Lifecycle Policies with this PR.