### PR TITLE
fix: Align the footer social links with the other Stackable sites 

### DIFF
--- a/ui/build.mjs
+++ b/ui/build.mjs
@@ -160,6 +160,9 @@ const icons = {
   search: 'solid/magnifying-glass',
   linkedin: 'brands/linkedin',
   github: 'brands/github',
+  youtube: 'brands/youtube',
+  rss: 'solid/rss',
+  discord: 'brands/discord',
   link: 'solid/link'
 };
 const symbols = Object.entries(icons).map(([name, faIcon]) => {

--- a/ui/src/partials/footer-content.hbs
+++ b/ui/src/partials/footer-content.hbs
@@ -63,6 +63,15 @@
           <a class="social-icon" href="https://github.com/stackabletech" target="_blank" aria-label="Stackable on GitHub">
             <svg class="svg-icon" aria-hidden="true"><use href="#icon-github"/></svg>
           </a>
+          <a class="social-icon" href="https://www.youtube.com/@stackabletech" target="_blank" aria-label="Stackable on YouTube">
+            <svg class="svg-icon" aria-hidden="true"><use href="#icon-youtube"/></svg>
+          </a>
+          <a class="social-icon" href="https://stackable.tech/en/feed/?category_name=news%2Cblog" target="_blank" aria-label="Stackable news and blog feed">
+            <svg class="svg-icon" aria-hidden="true"><use href="#icon-rss"/></svg>
+          </a>
+          <a class="social-icon" href="https://discord.com/invite/7kZ3BNnCAF" target="_blank" aria-label="Join the Stackable Discord community">
+            <svg class="svg-icon" aria-hidden="true"><use href="#icon-discord"/></svg>
+          </a>
         </div>
       </div>
       <p class="copyright-notice">


### PR DESCRIPTION
The title is a lie. It doesn't align with anything but I think it now covers everything from Hub & the homepage in a consistent way. So I believe this could be the new footer for all of them.